### PR TITLE
Bugfix: DocumentSplitter

### DIFF
--- a/src/RAG/Splitters/DocumentSplitter.php
+++ b/src/RAG/Splitters/DocumentSplitter.php
@@ -24,6 +24,7 @@ class DocumentSplitter
         }
 
         if (\strlen($text) <= $maxLength) {
+            if (empty($document->hash)) $document->hash = \hash('sha256', $text);
             return [$document];
         }
 


### PR DESCRIPTION
Ensure short documents still receive a hash. Documents with content shorter than maxlength would not be hashed.

Simple test:

```
$documents = StringDataLoader::for('test')->getDocuments();
print_r($documents);
```

```
Array
(
    [0] => NeuronAI\RAG\Document Object
        (
            [embedding] => 
            [sourceType] => manual
            [sourceName] => manual
            [hash] => 
            [chunkNumber] => 0
            [content] => test
        )

)
```
