### PR TITLE
Pass additional/custom params to OpenAI chat/completions endpoint

### DIFF
--- a/src/Providers/OpenAI/HandleChat.php
+++ b/src/Providers/OpenAI/HandleChat.php
@@ -27,6 +27,7 @@ trait HandleChat
         $json = [
             'model' => $this->model,
             'messages' => $mapper->map(),
+            ... $this->additional_params,
         ];
 
         // Attach tools
@@ -41,7 +42,9 @@ trait HandleChat
 
         if ($result['choices'][0]['finish_reason'] === 'tool_calls') {
             $response = $this->createToolMessage($result['choices'][0]['message']);
-        } else {
+        } elseif (isset($result['choices'][0]['message']['parsed'])) {
+            $response = new AssistantMessage($result['choices'][0]['message']['parsed']);
+        }else {
             $response = new AssistantMessage($result['choices'][0]['message']['content']);
         }
 

--- a/src/Providers/OpenAI/HandleChat.php
+++ b/src/Providers/OpenAI/HandleChat.php
@@ -42,8 +42,6 @@ trait HandleChat
 
         if ($result['choices'][0]['finish_reason'] === 'tool_calls') {
             $response = $this->createToolMessage($result['choices'][0]['message']);
-        } elseif (isset($result['choices'][0]['message']['parsed'])) {
-            $response = new AssistantMessage($result['choices'][0]['message']['parsed']);
         } else {
             $response = new AssistantMessage($result['choices'][0]['message']['content']);
         }

--- a/src/Providers/OpenAI/HandleChat.php
+++ b/src/Providers/OpenAI/HandleChat.php
@@ -27,7 +27,6 @@ trait HandleChat
         $json = [
             'model' => $this->model,
             'messages' => $mapper->map(),
-            ... $this->additional_params,
         ];
 
         // Attach tools
@@ -42,9 +41,7 @@ trait HandleChat
 
         if ($result['choices'][0]['finish_reason'] === 'tool_calls') {
             $response = $this->createToolMessage($result['choices'][0]['message']);
-        } elseif (isset($result['choices'][0]['message']['parsed'])) {
-            $response = new AssistantMessage($result['choices'][0]['message']['parsed']);
-        }else {
+        } else {
             $response = new AssistantMessage($result['choices'][0]['message']['content']);
         }
 

--- a/src/Providers/OpenAI/HandleChat.php
+++ b/src/Providers/OpenAI/HandleChat.php
@@ -27,6 +27,7 @@ trait HandleChat
         $json = [
             'model' => $this->model,
             'messages' => $mapper->map(),
+            ... $this->additional_params,
         ];
 
         // Attach tools
@@ -41,6 +42,8 @@ trait HandleChat
 
         if ($result['choices'][0]['finish_reason'] === 'tool_calls') {
             $response = $this->createToolMessage($result['choices'][0]['message']);
+        } elseif (isset($result['choices'][0]['message']['parsed'])) {
+            $response = new AssistantMessage($result['choices'][0]['message']['parsed']);
         } else {
             $response = new AssistantMessage($result['choices'][0]['message']['content']);
         }

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -46,7 +46,7 @@ class OpenAI implements AIProviderInterface
     public function __construct(
         protected string $key,
         protected string $model,
-        protected int $max_tokens = 1024,
+        protected array $additional_params = [],
     ) {
         $this->client = new Client([
             'base_uri' => $this->baseUri,
@@ -77,13 +77,10 @@ class OpenAI implements AIProviderInterface
 
             $properties = \array_reduce($tool->getProperties(), function (array $carry, ToolProperty $property) {
                 $carry[$property->getName()] = [
+                    'name' => $property->getName(),
                     'description' => $property->getDescription(),
                     'type' => $property->getType(),
                 ];
-
-                if (!empty($property->getEnum())) {
-                    $carry[$property->getName()]['enum'] = $property->getEnum();
-                }
 
                 return $carry;
             }, []);

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -46,7 +46,7 @@ class OpenAI implements AIProviderInterface
     public function __construct(
         protected string $key,
         protected string $model,
-        protected array $additional_params = [],
+        protected int $max_tokens = 1024,
     ) {
         $this->client = new Client([
             'base_uri' => $this->baseUri,
@@ -77,10 +77,13 @@ class OpenAI implements AIProviderInterface
 
             $properties = \array_reduce($tool->getProperties(), function (array $carry, ToolProperty $property) {
                 $carry[$property->getName()] = [
-                    'name' => $property->getName(),
                     'description' => $property->getDescription(),
                     'type' => $property->getType(),
                 ];
+
+                if (!empty($property->getEnum())) {
+                    $carry[$property->getName()]['enum'] = $property->getEnum();
+                }
 
                 return $carry;
             }, []);

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -46,7 +46,7 @@ class OpenAI implements AIProviderInterface
     public function __construct(
         protected string $key,
         protected string $model,
-        protected int $max_tokens = 1024,
+        protected array $additional_params = [],
     ) {
         $this->client = new Client([
             'base_uri' => $this->baseUri,


### PR DESCRIPTION
With this change we can 
- add additional params to chat API
- use $result['choices'][0]['message']['parsed'] in case we get back structured response