### PR TITLE
fix: Fixes input type for anthropics tool messages in cases where input is null

### DIFF
--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -103,9 +103,10 @@ class Anthropic implements AIProviderInterface
             ->setInputs($content['input']??[])
             ->setCallId($content['id']);
 
+        $content['input'] ??= (object)[];
+
         return new ToolCallMessage(
             [$content],
-            [$tool] // Anthropic call one tool at a time. So we pass an array with one element.
         );
     }
 }

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -107,6 +107,7 @@ class Anthropic implements AIProviderInterface
 
         return new ToolCallMessage(
             [$content],
+            [$tool] // Anthropic call one tool at a time. So we pass an array with one element.
         );
     }
 }


### PR DESCRIPTION
When input parameters are nullable the tool message chain will send `input: null` or in cases of empty arrays `input: []`
However, Anthropic requires input to be a json object. 

In this PR I just updated the input type for the tool message so that we don't have any downstream effects on tool execution. Haven't run into any issues so far. 