### PR TITLE
feat: add doctrine vector store

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,20 @@ on:
 jobs:
     ci:
         runs-on: ${{ matrix.os }}
+        services:
+            mariadb:
+                image: mariadb:11
+                env:
+                    MYSQL_DATABASE: neuron_ai_test
+                    MYSQL_USER: root
+                    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="healthcheck.sh --connect --innodb_initialized"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=3
         strategy:
             matrix:
                 os: [ubuntu-latest]

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         "symfony/serializer": "^5.4 || ^6.4 || ^7.0",
         "symfony/validator": "^5.4 || ^6.4 || ^7.0",
         "symfony/property-access": "^5.4 || ^6.4 || ^7.0",
-        "phpdocumentor/reflection-docblock": "^5.3 || ^5.6",
-        "doctrine/orm": "^2.20"
+        "phpdocumentor/reflection-docblock": "^5.3 || ^5.6"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "^7.0|^8.0",
         "inspector-apm/inspector-php": "^3.9",
         "symfony/process": "^4.0|^5.0|^6.0|^7.0",
         "typesense/typesense-php": "^5.0",
-        "php-http/curl-client": "^2.3"
+        "php-http/curl-client": "^2.3",
+        "doctrine/orm": "^2.20"
     },
     "require-dev": {
         "elasticsearch/elasticsearch": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
         "phpunit/phpunit": "^9.0",
         "symfony/process": "^5.0|^6.0|^7.0",
         "typesense/typesense-php": "^5.0",
-        "php-http/curl-client": "^2.3"
+        "php-http/curl-client": "^2.3",
+        "symfony/cache": "^5.4 || ^6.4 || ^7.0",
+        "ext-pdo": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         "guzzlehttp/guzzle": "^7.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/http-message": "^1.0|^2.0",
-        "symfony/property-info": "^6.4 || ^7.0",
-        "symfony/serializer": "^6.4 || ^7.0",
-        "symfony/validator": "^6.4 || ^7.0",
-        "symfony/property-access": "^6.4 || ^7.0",
-        "phpdocumentor/reflection-docblock": "^5.6"
+        "symfony/property-info": "^5.4 || ^6.4 || ^7.0",
+        "symfony/serializer": "^5.4 || ^6.4 || ^7.0",
+        "symfony/validator": "^5.4 || ^6.4 || ^7.0",
+        "symfony/property-access": "^5.4 || ^6.4 || ^7.0",
+        "phpdocumentor/reflection-docblock": "^5.3 || ^5.6",
+        "doctrine/orm": "^2.20"
     },
     "suggest": {
         "elasticsearch/elasticsearch": "^7.0|^8.0",

--- a/src/HandleStructured.php
+++ b/src/HandleStructured.php
@@ -21,6 +21,7 @@ use NeuronAI\StructuredOutput\Deserializer;
 use NeuronAI\StructuredOutput\JsonExtractor;
 use NeuronAI\StructuredOutput\JsonSchema;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Validation;
 
@@ -130,8 +131,9 @@ trait HandleStructured
         // Validate if the object fields respect the validation attributes
         // https://symfony.com/doc/current/validation.html#constraints
         $this->notify('structured-validating', new Validating($class, $json));
+        $loader = class_exists(AttributeLoader::class) ? new AttributeLoader() : new AnnotationLoader();
         $violations = Validation::createValidatorBuilder()
-            ->addLoader(new AttributeLoader())
+            ->addLoader($loader)
             ->getValidator()
             ->validate($obj);
 

--- a/src/RAG/VectorStore/Doctrine/AbstractDBL2OperatorDql.php
+++ b/src/RAG/VectorStore/Doctrine/AbstractDBL2OperatorDql.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+
+abstract class AbstractDBL2OperatorDql extends FunctionNode
+{
+    protected Node $vectorTwo;
+
+    protected Node $vectorOne;
+
+    public function parse(Parser $parser): void
+    {
+        if (class_exists(\Doctrine\ORM\Query\TokenType::class)) {
+            $parser->match(\Doctrine\ORM\Query\TokenType::T_IDENTIFIER);
+            $parser->match(\Doctrine\ORM\Query\TokenType::T_OPEN_PARENTHESIS);
+        } else {
+            $parser->match(\Doctrine\ORM\Query\Lexer::T_IDENTIFIER);
+            $parser->match(\Doctrine\ORM\Query\Lexer::T_OPEN_PARENTHESIS);
+        }
+
+        $this->vectorOne = $parser->ArithmeticFactor(); // Fix that, should be vector
+
+        if (class_exists(\Doctrine\ORM\Query\TokenType::class)) {
+            $parser->match(\Doctrine\ORM\Query\TokenType::T_COMMA);
+        } else {
+            $parser->match(\Doctrine\ORM\Query\Lexer::T_COMMA);
+        }
+
+        $this->vectorTwo = $parser->ArithmeticFactor(); // Fix that, should be vector
+
+        if (class_exists(\Doctrine\ORM\Query\TokenType::class)) {
+            $parser->match(\Doctrine\ORM\Query\TokenType::T_CLOSE_PARENTHESIS);
+        } else {
+            $parser->match(\Doctrine\ORM\Query\Lexer::T_CLOSE_PARENTHESIS);
+        }
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/DoctrineEmbeddingEntityBase.php
+++ b/src/RAG/VectorStore/Doctrine/DoctrineEmbeddingEntityBase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use NeuronAI\RAG\Document;
+
+#[ORM\MappedSuperclass]
+abstract class DoctrineEmbeddingEntityBase extends Document
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public mixed $id;
+
+    #[ORM\Column(type: VectorType::VECTOR, length: 3072)]
+    public ?array $embedding;
+
+    #[ORM\Column(type: Types::TEXT)]
+    public string $content;
+
+    #[ORM\Column(type: Types::TEXT)]
+    public string $sourceType = 'manual';
+
+    #[ORM\Column(type: Types::TEXT)]
+    public string $sourceName = 'manual';
+
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $chunkNumber = 0;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/DoctrineVectorStore.php
+++ b/src/RAG/VectorStore/Doctrine/DoctrineVectorStore.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\ORMException;
+use Exception;
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\VectorStore\VectorStoreInterface;
+
+class DoctrineVectorStore implements VectorStoreInterface
+{
+    private readonly SupportedDoctrineVectorStore $doctrineVectorStoreType;
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        public readonly string $entityClassName
+    ) {
+        if (!interface_exists(EntityManagerInterface::class)) {
+            throw new \RuntimeException('To use this functionality, you must install the `doctrine/orm` package: `composer require doctrine/orm`.');
+        }
+
+        $conn = $entityManager->getConnection();
+        $this->doctrineVectorStoreType = SupportedDoctrineVectorStore::fromPlatform($conn->getDatabasePlatform());
+        $registeredTypes = Type::getTypesMap();
+        if (!array_key_exists(VectorType::VECTOR, $registeredTypes)) {
+            Type::addType(VectorType::VECTOR, VectorType::class);
+            $conn->getDatabasePlatform()->registerDoctrineTypeMapping('vector', VectorType::VECTOR);
+        }
+
+        $this->doctrineVectorStoreType->addCustomisationsTo($this->entityManager);
+    }
+
+    public function addDocument(Document $document): void
+    {
+        if ($document->embedding === null) {
+            throw new \RuntimeException('document embedding must be set before adding a document');
+        }
+
+        $this->persistDocument($document);
+        $this->entityManager->flush();
+    }
+
+    public function addDocuments(array $documents): void
+    {
+        if ($documents === []) {
+            return;
+        }
+        foreach ($documents as $document) {
+            $this->persistDocument($document);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    public function similaritySearch(array $embedding, int $k = 4, array $additionalArguments = []): array
+    {
+        $repository = $this->entityManager->getRepository($this->entityClassName);
+
+        $qb = $repository
+            ->createQueryBuilder('e')
+            ->orderBy($this->doctrineVectorStoreType->l2DistanceName().'(e.embedding, :embeddingString)', 'ASC')
+            ->setParameter('embeddingString', $this->doctrineVectorStoreType->getVectorAsString($embedding))
+            ->setMaxResults($k);
+
+        foreach ($additionalArguments as $key => $value) {
+            $paramName = 'where_'.$key;
+            $qb
+                ->andWhere(sprintf('e.%s = :%s', $key, $paramName))
+                ->setParameter($paramName, $value);
+        }
+
+        /** @var DoctrineEmbeddingEntityBase[] */
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @throws ORMException
+     * @throws Exception
+     */
+    private function persistDocument(Document $document): void
+    {
+        if (empty($document->embedding)) {
+            throw new \RuntimeException('Trying to save a document in a vectorStore without embedding');
+        }
+
+        if (!$document instanceof DoctrineEmbeddingEntityBase) {
+            throw new \RuntimeException('Document needs to be an instance of DoctrineEmbeddingEntityBase');
+        }
+
+        $this->entityManager->persist($document);
+    }
+
+    /**
+     * @return iterable<Document>
+     */
+    public function fetchDocumentsByChunkRange(string $sourceType, string $sourceName, int $leftIndex, int $rightIndex): iterable
+    {
+        $repository = $this->entityManager->getRepository($this->entityClassName);
+
+        $query = $repository->createQueryBuilder('d')
+            ->andWhere('d.sourceType = :sourceType')
+            ->andWhere('d.sourceName = :sourceName')
+            ->andWhere('d.chunkNumber >= :lower')
+            ->andWhere('d.chunkNumber <= :upper')
+            ->setParameter('sourceType', $sourceType)
+            ->setParameter('sourceName', $sourceName)
+            ->setParameter('lower', $leftIndex)
+            ->setParameter('upper', $rightIndex)
+            ->getQuery();
+
+        return $query->toIterable();
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/MariaDBVectorL2OperatorDql.php
+++ b/src/RAG/VectorStore/Doctrine/MariaDBVectorL2OperatorDql.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * L2DistanceFunction ::= "VEC_DISTANCE_EUCLIDEAN" "(" VectorPrimary "," VectorPrimary ")"
+ */
+final class MariaDBVectorL2OperatorDql extends AbstractDBL2OperatorDql
+{
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return 'VEC_DISTANCE_EUCLIDEAN('.
+            $this->vectorOne->dispatch($sqlWalker).', '.
+            'VEC_FROMTEXT('.
+            $this->vectorTwo->dispatch($sqlWalker).
+            ')'.
+            ')';
+    }
+}
+

--- a/src/RAG/VectorStore/Doctrine/MariaDBVectorStoreType.php
+++ b/src/RAG/VectorStore/Doctrine/MariaDBVectorStoreType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class MariaDBVectorStoreType extends SupportedDoctrineVectorStore
+{
+    public function getVectorAsString(array $vector): string
+    {
+        return '['.$this->stringListOf($vector).']';
+    }
+
+    public function convertToDatabaseValueSQL(string $sqlExpr): string
+    {
+        return sprintf('Vec_FromText(%s)', $sqlExpr);
+    }
+
+    public function addCustomisationsTo(EntityManagerInterface $entityManager): void
+    {
+        $entityManager->getConfiguration()->addCustomStringFunction($this->l2DistanceName(), MariaDBVectorL2OperatorDql::class);
+    }
+
+    public function l2DistanceName(): string
+    {
+        return 'VEC_DISTANCE_EUCLIDEAN';
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/PostgresqlVectorL2OperatorDql.php
+++ b/src/RAG/VectorStore/Doctrine/PostgresqlVectorL2OperatorDql.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * L2DistanceFunction ::= "L2_DISTANCE" "(" VectorPrimary "," VectorPrimary ")"
+ */
+final class PostgresqlVectorL2OperatorDql extends AbstractDBL2OperatorDql
+{
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return 'L2_DISTANCE('.
+            $this->vectorOne->dispatch($sqlWalker).', '.
+            $this->vectorTwo->dispatch($sqlWalker).
+            ')';
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/PostgresqlVectorStoreType.php
+++ b/src/RAG/VectorStore/Doctrine/PostgresqlVectorStoreType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class PostgresqlVectorStoreType extends SupportedDoctrineVectorStore
+{
+    public function getVectorAsString(array $vector): string
+    {
+        return '['.$this->stringListOf($vector).']';
+    }
+
+    public function convertToDatabaseValueSQL(string $sqlExpr): string
+    {
+        return $sqlExpr;
+    }
+
+    public function addCustomisationsTo(EntityManagerInterface $entityManager): void
+    {
+        $entityManager->getConfiguration()->addCustomStringFunction($this->l2DistanceName(), PostgresqlVectorL2OperatorDql::class);
+    }
+
+    public function l2DistanceName(): string
+    {
+        return 'VEC_DISTANCE_EUCLIDEAN';
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/SupportedDoctrineVectorStore.php
+++ b/src/RAG/VectorStore/Doctrine/SupportedDoctrineVectorStore.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\EntityManagerInterface;
+
+abstract class SupportedDoctrineVectorStore
+{
+    /**
+     * @param  float[]  $vector
+     */
+    abstract public function getVectorAsString(array $vector): string;
+
+    abstract public function convertToDatabaseValueSQL(string $sqlExpr): string;
+
+    abstract public function addCustomisationsTo(EntityManagerInterface $entityManager): void;
+
+    abstract public function l2DistanceName(): string;
+
+    /**
+     * @param  float[]  $vector
+     */
+    protected function stringListOf(array $vector): string
+    {
+        return \implode(',', $vector);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function values(): array
+    {
+        return [
+            'postgresql',
+            'mysql',
+        ];
+    }
+
+    public static function fromPlatform(AbstractPlatform $platform): self
+    {
+        if (str_starts_with($platform::class, 'Doctrine\DBAL\Platforms\MariaDb')) {
+            return new MariaDBVectorStoreType();
+        }
+        if (str_starts_with($platform::class, 'Doctrine\DBAL\Platforms\PostgreSQL')) {
+            return new PostgresqlVectorStoreType();
+        }
+
+        throw new \RuntimeException('Unsupported DoctrineVectorStore type');
+    }
+}

--- a/src/RAG/VectorStore/Doctrine/VectorType.php
+++ b/src/RAG/VectorStore/Doctrine/VectorType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace NeuronAI\RAG\VectorStore\Doctrine;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class VectorType extends Type
+{
+    final public const VECTOR = 'vector';
+
+    /**
+     * @param  mixed[]  $column
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        // getName is deprecated since doctrine/dbal 2.13 see: https://github.com/doctrine/dbal/issues/4749
+        // BUT it is the most stable way to check if the platform is PostgreSQLPlatform in a lot of doctrine versions
+        // so we will use it and add a check for the class name in case it is removed in the future
+        if (method_exists($platform, 'getName') && ! \in_array($platform->getName(), SupportedDoctrineVectorStore::values())) {
+            throw Exception::notSupported('VECTORs not supported by Platform.');
+        }
+
+        if (! isset($column['length'])) {
+            throw Exception::notSupported('VECTORs must have a length.');
+        }
+
+        if ($column['length'] < 1) {
+            throw Exception::notSupported('VECTORs must have a length greater than 0.');
+        }
+
+        if (! is_int($column['length'])) {
+            throw Exception::notSupported('VECTORs must have a length that is an integer.');
+        }
+
+        return sprintf('vector(%d)', $column['length']);
+    }
+
+    /**
+     * @return float[]
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        $value = is_resource($value) ? stream_get_contents($value) : $value;
+
+        if (! is_string($value)) {
+            throw Exception::notSupported('Error while converting VECTORs to PHP value.');
+        }
+
+        $convertedValue = explode(',', $value);
+        $floatArray = [];
+        foreach ($convertedValue as $singleConvertedValue) {
+            $floatArray[] = (float) $singleConvertedValue;
+        }
+
+        return $floatArray;
+    }
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): string
+    {
+        //If $value is not a float array throw an exception
+        if (! is_array($value)) {
+            throw Exception::notSupported('VECTORs must be an array.');
+        }
+
+        return SupportedDoctrineVectorStore::fromPlatform($platform)->getVectorAsString($value);
+    }
+
+    public function convertToDatabaseValueSQL(mixed $sqlExpr, AbstractPlatform $platform): string
+    {
+        return SupportedDoctrineVectorStore::fromPlatform($platform)->convertToDatabaseValueSQL($sqlExpr);
+    }
+
+    public function canRequireSQLConversion(): bool
+    {
+        return true;
+    }
+
+    public function getName(): string
+    {
+        return self::VECTOR;
+    }
+}

--- a/tests/Traits/NeedsDatabaseBootstrap.php
+++ b/tests/Traits/NeedsDatabaseBootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace NeuronAI\Tests\Traits;
+
+trait NeedsDatabaseBootstrap
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $scriptPath = __DIR__ . '/../scripts/setup-test-db.php';
+
+        if (!file_exists($scriptPath)) {
+            throw new \RuntimeException("Bootstrap script not found at $scriptPath");
+        }
+
+        require_once $scriptPath;
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -8,33 +8,36 @@ use NeuronAI\Tests\Utils\PersonWithAddress;
 use NeuronAI\Tests\Utils\PersonWithTags;
 use NeuronAI\Tests\Utils\Tag;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Validation;
 
 class ValidatorTest extends TestCase
 {
-    public function test_valid()
+    public function test_valid(): void
     {
         $obj = new Person();
         $obj->firstName = 'John';
         $obj->lastName = 'Doe';
 
+        $loader = class_exists(AttributeLoader::class) ? new AttributeLoader() : new AnnotationLoader();
         $violations = Validation::createValidatorBuilder()
-            ->addLoader(new AttributeLoader())
+            ->addLoader($loader)
             ->getValidator()
             ->validate($obj);
 
         $this->assertEquals(0, $violations->count());
     }
 
-    public function test_not_valid()
+    public function test_not_valid(): void
     {
         $obj = new Person();
         $obj->lastName = 'Doe';
 
+        $loader = class_exists(AttributeLoader::class) ? new AttributeLoader() : new AnnotationLoader();
         $violations = Validation::createValidatorBuilder()
-            ->addLoader(new AttributeLoader())
+            ->addLoader($loader)
             ->getValidator()
             ->validate($obj);
 
@@ -46,7 +49,7 @@ class ValidatorTest extends TestCase
         }
     }
 
-    public function test_validate_nested_class()
+    public function test_validate_nested_class(): void
     {
         $obj = new PersonWithAddress();
         $obj->firstName = 'John';
@@ -54,8 +57,9 @@ class ValidatorTest extends TestCase
         $obj->address = new Address();
         $obj->address->city = 'Rome';
 
+        $loader = class_exists(AttributeLoader::class) ? new AttributeLoader() : new AnnotationLoader();
         $violations = Validation::createValidatorBuilder()
-            ->addLoader(new AttributeLoader())
+            ->addLoader($loader)
             ->getValidator()
             ->validate($obj);
 
@@ -68,7 +72,7 @@ class ValidatorTest extends TestCase
         }
     }
 
-    public function test_validate_array()
+    public function test_validate_array(): void
     {
         $obj = new PersonWithTags();
         $obj->firstName = 'John';
@@ -78,22 +82,24 @@ class ValidatorTest extends TestCase
         $tag->name = 'agent';
         $obj->tags = [$tag];
 
+        $loader = class_exists(AttributeLoader::class) ? new AttributeLoader() : new AnnotationLoader();
         $violations = Validation::createValidatorBuilder()
-            ->addLoader(new AttributeLoader())
+            ->addLoader($loader)
             ->getValidator()
             ->validate($obj);
 
         $this->assertEquals(0, $violations->count());
     }
 
-    public function test_array_not_valid()
+    public function test_array_not_valid(): void
     {
         $obj = new PersonWithTags();
         $obj->firstName = 'John';
         $obj->lastName = 'Doe';
 
+        $loader = class_exists(AttributeLoader::class) ? new AttributeLoader() : new AnnotationLoader();
         $violations = Validation::createValidatorBuilder()
-            ->addLoader(new AttributeLoader())
+            ->addLoader($loader)
             ->getValidator()
             ->validate($obj);
 

--- a/tests/VectorStore/DoctrineVectorStoreTest.php
+++ b/tests/VectorStore/DoctrineVectorStoreTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace NeuronAI\Tests\VectorStore;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
+use NeuronAI\RAG\VectorStore\Doctrine\DoctrineVectorStore;
+use NeuronAI\RAG\VectorStore\Doctrine\VectorType;
+use NeuronAI\Tests\stubs\EntityVectorStub;
+use NeuronAI\Tests\Traits\NeedsDatabaseBootstrap;
+use PHPUnit\Framework\TestCase;
+
+class DoctrineVectorStoreTest extends TestCase
+{
+    private const TYPE_NAME = 'vector';
+    private const EMBEDDING_SIZE = 3072;
+    private EntityManager $entityManager;
+    private SchemaTool $schemaTool;
+    private ClassMetadata $metadata;
+
+    use NeedsDatabaseBootstrap;
+
+    protected function setUp(): void
+    {
+        if (!Type::hasType(self::TYPE_NAME)) {
+            Type::addType(self::TYPE_NAME, VectorType::class);
+        }
+
+        $config = ORMSetup::createAttributeMetadataConfiguration(
+            paths: [__DIR__ . '/../../src/RAG'],
+            isDevMode: true,
+            reportFieldsWhereDeclared: true,
+        );
+
+        $connection = DriverManager::getConnection([
+            'dbname'   => 'neuron_ai_test',
+            'user'     => 'root',
+            'password' => '',
+            'host'     => '127.0.0.1',
+            'port'     => 3306,
+            'driver'   => 'pdo_mysql',
+        ], $config);
+
+        $platform = $connection->getDatabasePlatform();
+        if (!$platform->hasDoctrineTypeMappingFor('vector')) {
+            $platform->registerDoctrineTypeMapping('vector', 'vector');
+        }
+
+        $this->entityManager = new EntityManager($connection, $config);
+        $this->schemaTool = new SchemaTool($this->entityManager);
+        $this->metadata = $this->entityManager->getClassMetadata(EntityVectorStub::class);
+        $this->schemaTool->createSchema([$this->metadata]);
+        $this->embeddingToSearch = json_decode(file_get_contents(__DIR__ . '/../stubs/hello-world.embeddings'), true);
+    }
+
+    /**
+     * @dataProvider provideVectors
+     */
+    public function test_add_documents_and_search(array $embeddings, array $expectedEmbeddings): void {
+        $documents = [];
+        foreach ($embeddings as $embedding) {
+            $document = new EntityVectorStub();
+            $document->embedding = $embedding;
+            $documents[] = $document;
+        }
+
+        $vectorStore = new DoctrineVectorStore($this->entityManager, EntityVectorStub::class);
+        $vectorStore->addDocuments($documents);
+
+        $entitiesVectorStub = $vectorStore->similaritySearch($this->embeddingToSearch, 2);
+
+        $this->assertCount(2, $entitiesVectorStub);
+        foreach ($entitiesVectorStub as $index => $entityVectorStub) {
+            $this->assertEquals($expectedEmbeddings[$index], $entityVectorStub->embedding);
+        }
+    }
+
+    public function provideVectors(): array
+    {
+        return [
+            [
+                [
+                    $this->generateVectors([0.512, -0.341, 0.123]),
+                    $this->generateVectors([-0.278, 0.659, -0.487]),
+                    $this->generateVectors([0.194, -0.055, 0.732]),
+                ],
+                [
+                    $this->generateVectors([0.512, -0.341, 0.123]),
+                    $this->generateVectors([-0.278, 0.659, -0.487]),
+                    $this->generateVectors([0.194, -0.055, 0.732]),
+                ]
+            ],
+        ];
+    }
+
+    private function generateVectors(array $vectors): array
+    {
+        $result = [];
+        $count = count($vectors);
+
+        for ($i = 0; $i < self::EMBEDDING_SIZE; $i++) {
+            $result[] = $vectors[$i % $count];
+        }
+
+        return $result;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->schemaTool->dropSchema([$this->metadata]);
+    }
+}

--- a/tests/scripts/setup-test-db.php
+++ b/tests/scripts/setup-test-db.php
@@ -1,0 +1,28 @@
+<?php
+
+$host = '127.0.0.1';
+$port = 3306;
+$user = 'root';
+$password = '';
+$database = 'neuron_ai_test';
+
+try {
+    $pdo = new PDO("mysql:host=$host;port=$port", $user, $password, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+
+    $stmt = $pdo->query("SHOW DATABASES LIKE " . $pdo->quote($database));
+    $exists = $stmt->fetch();
+
+    if (!$exists) {
+        echo "🛠️  Database '$database' does not exist, creating...\n";
+        $pdo->exec("CREATE DATABASE `$database` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;");
+        echo "✅ Database '$database' created successfully.\n";
+    } else {
+        echo "✅ Database '$database' already exists. Everything is ready.\n";
+    }
+
+} catch (PDOException $e) {
+    echo "❌ Connection or database creation error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/tests/stubs/EntityVectorStub.php
+++ b/tests/stubs/EntityVectorStub.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace NeuronAI\Tests\stubs;
+
+use Doctrine\ORM\Mapping as ORM;
+use NeuronAI\RAG\VectorStore\Doctrine\DoctrineEmbeddingEntityBase;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'entity_vector_stub')]
+class EntityVectorStub extends DoctrineEmbeddingEntityBase
+{
+}


### PR DESCRIPTION
This pull request introduces the initial implementation of a vector store integration using Doctrine based on code originally from [llphant](https://github.com/LLPhant/LLPhant).

The goal is to enable storage and retrieval of vector embeddings directly through the database layer using Doctrine entities. This is part of the broader effort to support semantic search and similarity-based operations within the application.