### PR TITLE
Add missing sourceType and sourceName metadata to Pinecone and Qdrant VectorStores

### DIFF
--- a/src/RAG/VectorStore/PineconeVectorStore.php
+++ b/src/RAG/VectorStore/PineconeVectorStore.php
@@ -39,7 +39,11 @@ class PineconeVectorStore implements VectorStoreInterface
                     return [
                         'id' => $document->id??\uniqid(),
                         'values' => $document->embedding,
-                        'metadata' => ['content' => $document->content],
+                        'metadata' => [
+                            'content' => $document->content,
+                            'sourceType' => $document->sourceType,
+                            'sourceName' => $document->sourceName,
+                        ],
                     ];
                 }, $documents)
             ]
@@ -64,6 +68,8 @@ class PineconeVectorStore implements VectorStoreInterface
             $document->id = $item['id'];
             $document->embedding = $item['values'];
             $document->content = $item['metadata']['content'];
+            $document->sourceType = $item['metadata']['sourceType'];
+            $document->sourceName = $item['metadata']['sourceName'];
             return $document;
         }, $result['matches']);
     }

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -39,6 +39,8 @@ class QdrantVectorStore implements VectorStoreInterface
                 'id' => $document->id,
                 'payload' => [
                     'content' => $document->content,
+                    'sourceType' => $document->sourceType,
+                    'sourceName' => $document->sourceName,
                 ],
                 'vector' => $document->embedding,
             ]
@@ -59,6 +61,8 @@ class QdrantVectorStore implements VectorStoreInterface
                 'id' => $document->id,
                 'payload' => [
                     'content' => $document->content,
+                    'sourceType' => $document->sourceType,
+                    'sourceName' => $document->sourceName,
                 ],
                 'vector' => $document->embedding,
             ];
@@ -83,6 +87,8 @@ class QdrantVectorStore implements VectorStoreInterface
             $document->id = $item['id'];
             $document->embedding = $item['vector'];
             $document->content = $item['payload']['content'];
+            $document->sourceType = $item['payload']['sourceType'];
+            $document->sourceName = $item['payload']['sourceName'];
             return $document;
         }, $response['result']);
     }


### PR DESCRIPTION
This pull request addresses the inconsistency in metadata handling across different VectorStores. The sourceType and sourceName metadata were already present in the Document and ElasticsearchVectorStore but were missing in the Pinecone and Qdrant VectorStores. By adding these metadata fields, we ensure uniformity and enhance the traceability of documents across all storage solutions.