### PR TITLE
Enhance RAG Module with Post-Processor Support and Jina Reranking

### DIFF
--- a/src/RAG/PostProcessor/HandleClient.php
+++ b/src/RAG/PostProcessor/HandleClient.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace NeuronAI\RAG\PostProcessor;
+
+use GuzzleHttp\Client;
+
+trait HandleClient
+{
+    public function setClient(Client $client): PostProcessorInterface
+    {
+        $this->client = $client;
+        return $this;
+    }
+}

--- a/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
+++ b/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
@@ -9,8 +9,25 @@ class JinaRerankerPostProcessor implements PostProcessorInterface
 {
     use HandleClient;
 
+    /**
+     * The http client.
+     *
+     * @var Client
+     */
     protected Client $client;
+
+    /**
+     * The model to use for the reranking.
+     *
+     * @var string
+     */
     protected string $model;
+
+    /**
+     * The number of documents to return.
+     *
+     * @var int
+     */
     protected int $topN;
 
     public function __construct(string $apiKey, string $model = 'jina-reranker-v2-base-multilingual', int $topN = 3)

--- a/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
+++ b/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
@@ -5,7 +5,7 @@ namespace NeuronAI\RAG\PostProcessor;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 
-class JinaRerankerPostProcessor
+class JinaRerankerPostProcessor implements PostProcessorInterface
 {
     protected Client $client;
     protected string $model;

--- a/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
+++ b/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace NeuronAI\RAG\PostProcessor;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+
+class JinaRerankerPostProcessor
+{
+    protected Client $client;
+    protected string $model;
+    protected int $topN;
+
+    public function __construct(string $apiKey, string $model = 'jina-reranker-v2-base-multilingual', int $topN = 3)
+    {
+        $this->client = new Client([
+            'base_uri' => 'https://api.jina.ai/v1/',
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer '.$apiKey,
+            ],
+        ]);
+
+        $this->model = $model;
+        $this->topN = $topN;
+    }
+
+    public function postProcess(string $question, array $documents): array
+    {
+        return $this->rerank($question, $documents, $this->topN);
+    }
+
+    private function rerank(string $query, array $documents, int $topN): array
+    {
+        $response = $this->client->post('rerank', [
+            RequestOptions::JSON => [
+                'model' => $this->model,
+                'query' => $query,
+                'top_n' => $topN,
+                'documents' => $documents,
+                'return_documents' => false,
+            ],
+        ]);
+
+        $body = $response->getBody()->getContents();
+        $result = \json_decode($body, true);
+
+        $rerankedDocuments = [];
+
+        foreach ($result['results'] as $result) {
+            $rerankedDocuments[] = $documents[$result['index']];
+        }
+
+        return $rerankedDocuments;
+    }
+}

--- a/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
+++ b/src/RAG/PostProcessor/JinaRerankerPostProcessor.php
@@ -7,6 +7,8 @@ use GuzzleHttp\RequestOptions;
 
 class JinaRerankerPostProcessor implements PostProcessorInterface
 {
+    use HandleClient;
+
     protected Client $client;
     protected string $model;
     protected int $topN;

--- a/src/RAG/PostProcessor/PostProcessorInterface.php
+++ b/src/RAG/PostProcessor/PostProcessorInterface.php
@@ -9,8 +9,9 @@ interface PostProcessorInterface
     /**
      * Process an array of documents and return the processed documents.
      *
-     * @param array<Document> $documents
-     * @return array<Document>
+     * @param string $question The question to process the documents for.
+     * @param array<Document> $documents The documents to process.
+     * @return array<Document> The processed documents.
      */
     public function postProcess(string $question, array $documents): array;
 }

--- a/src/RAG/PostProcessor/PostProcessorInterface.php
+++ b/src/RAG/PostProcessor/PostProcessorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NeuronAI\RAG\PostProcessor;
+
+use NeuronAI\RAG\Document;
+
+interface PostProcessorInterface
+{
+    /**
+     * Process an array of documents and return the processed documents.
+     *
+     * @param array<Document> $documents
+     * @return array<Document>
+     */
+    public function postProcess(string $question, array $documents): array;
+}

--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -11,6 +11,7 @@ use NeuronAI\Observability\Events\VectorStoreSearching;
 use NeuronAI\Exceptions\MissingCallbackParameter;
 use NeuronAI\Exceptions\ToolCallableNotSet;
 use NeuronAI\RAG\Embeddings\EmbeddingsProviderInterface;
+use NeuronAI\RAG\PostProcessor\PostProcessorInterface;
 use NeuronAI\RAG\VectorStore\VectorStoreInterface;
 use NeuronAI\SystemPrompt;
 
@@ -27,6 +28,16 @@ class RAG extends Agent
      * @var EmbeddingsProviderInterface
      */
     protected EmbeddingsProviderInterface $embeddingsProvider;
+
+    /**
+     * @var array<PostprocessorInterface>
+     */
+    protected array $postProcessors = [];
+
+    /**
+     * @var array<Document>
+     */
+    protected array $retrievedDocuments;
 
     /**
      * @throws MissingCallbackParameter
@@ -61,10 +72,12 @@ class RAG extends Agent
             'rag-vectorstore-searching',
             new VectorStoreSearching($question)
         );
-        $documents = $this->searchDocuments($question->getContent(), $k);
+        $this->retrievedDocuments = $this->searchDocuments($question->getContent(), $k);
+        $this->retrievedDocuments = $this->applyPostProcessors($question->getContent(), $this->retrievedDocuments);
+
         $this->notify(
             'rag-vectorstore-result',
-            new VectorStoreResult($question, $documents)
+            new VectorStoreResult($question, $this->retrievedDocuments)
         );
 
         $originalInstructions = $this->instructions();
@@ -72,7 +85,7 @@ class RAG extends Agent
             'rag-instructions-changing',
             new InstructionsChanging($originalInstructions)
         );
-        $this->setSystemMessage($documents, $k);
+        $this->setSystemMessage($this->retrievedDocuments, $k);
         $this->notify(
             'rag-instructions-changed',
             new InstructionsChanged($originalInstructions, $this->instructions())
@@ -125,6 +138,25 @@ class RAG extends Agent
         return \array_values($retrievedDocs);
     }
 
+    /**
+     * Apply a series of postprocessors to the retrieved documents.
+     *
+     * @param array<Document> $documents
+     * @return array<Document>
+     */
+    protected function applyPostProcessors(string $question, array $documents): array
+    {
+        $postProcessors = $this->postProcessors();
+
+        foreach ($postProcessors as $postProcessor) {
+            if ($postProcessor instanceof PostProcessorInterface) {
+                $documents = $postProcessor->postProcess($question, $documents);
+            }
+        }
+
+        return $documents;
+    }
+
     public function setEmbeddingsProvider(EmbeddingsProviderInterface $provider): self
     {
         $this->embeddingsProvider = $provider;
@@ -145,5 +177,22 @@ class RAG extends Agent
     protected function vectorStore(): VectorStoreInterface
     {
         return $this->store;
+    }
+
+    /**
+     * @param array<PostprocessorInterface> $postProcessors
+     */
+    public function setPostProcessors(array $postProcessors): self
+    {
+        $this->postProcessors = $postProcessors;
+        return $this;
+    }
+
+    /**
+     * @return array<PostprocessorInterface>
+     */
+    protected function postProcessors(): array
+    {
+        return $this->postProcessors;
     }
 }

--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -195,4 +195,14 @@ class RAG extends Agent
     {
         return $this->postProcessors;
     }
+
+    /**
+     * Get the retrieved documents from the vector store.
+     *
+     * @return array<Document>
+     */
+    public function getRetrievedDocuments(): array
+    {
+        return $this->retrievedDocuments;
+    }
 }

--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -141,8 +141,9 @@ class RAG extends Agent
     /**
      * Apply a series of postprocessors to the retrieved documents.
      *
-     * @param array<Document> $documents
-     * @return array<Document>
+     * @param string $question The question to process the documents for.
+     * @param array<Document> $documents The documents to process.
+     * @return array<Document> The processed documents.
      */
     protected function applyPostProcessors(string $question, array $documents): array
     {

--- a/tests/PostProcessor/JinaRerankerPostProcessorTest.php
+++ b/tests/PostProcessor/JinaRerankerPostProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace NeuronAI\Tests\PostProcessor;
+
+use NeuronAI\RAG\PostProcessor\JinaRerankerPostProcessor;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+
+class JinaRerankerPostProcessorTest extends TestCase
+{
+    public function test_post_process_reranks_documents()
+    {
+        $sentRequests = [];
+        $history = Middleware::history($sentRequests);
+        $mockHandler = new MockHandler([
+            new Response(
+                status: 200,
+                body: json_encode([
+                    'results' => [
+                        ['index' => 1, 'score' => 0.9],
+                        ['index' => 0, 'score' => 0.2],
+                        ['index' => 2, 'score' => 0.1]
+                    ]
+                ])
+            )
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $postProcessor = (new JinaRerankerPostProcessor(''))->setClient($client);
+
+        $question = "What is the capital of Italy?";
+        $documents = [
+            "Paris is the capital of France",
+            "Rome is the capital of Italy",
+            "Madrid is the capital of Spain",
+            "London is the capital of the United Kingdom"
+        ];
+
+        $result = $postProcessor->postProcess($question, $documents);
+
+        $this->assertCount(3, $result, "Jina API returns 3 results by default");
+        $this->assertEquals("Rome is the capital of Italy", $result[0], "Rome should be the first result");
+        $this->assertEquals("Paris is the capital of France", $result[1], "Paris should be the second result");
+        $this->assertEquals("Madrid is the capital of Spain", $result[2], "Madrid should be the third result");
+    }
+
+    public function test_post_process_with_top_n_parameter()
+    {
+        $sentRequests = [];
+        $history = Middleware::history($sentRequests);
+        $mockHandler = new MockHandler([
+            new Response(
+                status: 200,
+                body: json_encode([
+                    'results' => [
+                        ['index' => 1, 'score' => 0.9],
+                        ['index' => 0, 'score' => 0.2]
+                    ]
+                ])
+            )
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $postProcessor = (new JinaRerankerPostProcessor('', 'jina-reranker-v2-base-multilingual', 2))->setClient($client);
+
+        $question = "What is the capital of Italy?";
+        $documents = [
+            "Paris is the capital of France",
+            "Rome is the capital of Italy",
+            "Madrid is the capital of Spain",
+            "London is the capital of the United Kingdom"
+        ];
+
+        $result = $postProcessor->postProcess($question, $documents);
+
+        $this->assertCount(2, $result, "Jina API returns exactly top_n results");
+        $this->assertEquals("Rome is the capital of Italy", $result[0], "Rome should be the first result");
+        $this->assertEquals("Paris is the capital of France", $result[1], "Paris should be the second result");
+    }
+}


### PR DESCRIPTION
These updates improve document retrieval accuracy and flexibility in the RAG module.

Key Changes:
- Introduced `PostProcessorInterface` and integrated post-processor handling in RAG.
- Added `JinaRerankerPostProcessor` to reorder documents using Jina's API.
- Implemented `getRetrievedDocuments()` method for accessing retrieved documents.

Please review and provide feedback.