### PR TITLE
Adding ArrayOf attribute for arrays in Structured Output

### DIFF
--- a/src/StructuredOutput/ArrayOf.php
+++ b/src/StructuredOutput/ArrayOf.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace NeuronAI\StructuredOutput;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ArrayOf
+{
+    public function __construct(public string $class)
+    {}
+}

--- a/src/StructuredOutput/ArrayOf.php
+++ b/src/StructuredOutput/ArrayOf.php
@@ -3,10 +3,15 @@
 namespace NeuronAI\StructuredOutput;
 
 use Attribute;
+use InvalidArgumentException;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class ArrayOf
 {
     public function __construct(public string $class)
-    {}
+    {
+        if (!class_exists($class) && !enum_exists($class)) {
+            throw new InvalidArgumentException("Class $class does not exist.");
+        }
+    }
 }

--- a/src/StructuredOutput/JsonSchema.php
+++ b/src/StructuredOutput/JsonSchema.php
@@ -163,6 +163,7 @@ class JsonSchema
 
             // Parse PHPDoc for the array item type
             $docComment = $property->getDocComment();
+            $attributes = $property->getAttributes(ArrayOf::class);
             if ($docComment) {
                 // Extract type from @var array<Type>
                 preg_match('/@var\s+array<([^>]*)>/', $docComment, $matches);
@@ -179,6 +180,14 @@ class JsonSchema
                     }
                 } else {
                     // Default to string if no specific type found
+                    $schema['items'] = ['type' => 'string'];
+                }
+            } elseif($attributes) {
+                $itemClass = $attributes[0]->getArguments()[0];
+                if (class_exists($itemClass) || enum_exists($itemClass)) {
+                    $schema['items'] = $this->generateClassSchema($itemClass, false);
+                } else {
+                    // Fallback if class in ArrayOf does not exist (should ideally not happen if used correctly)
                     $schema['items'] = ['type' => 'string'];
                 }
             } else {

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -2,11 +2,12 @@
 
 namespace NeuronAI\Tests;
 
+use NeuronAI\StructuredOutput\ArrayOf;
 use NeuronAI\StructuredOutput\JsonSchema;
 use NeuronAI\StructuredOutput\SchemaProperty;
-use NeuronAI\Tests\Utils\Person;
 use NeuronAI\Tests\Utils\PersonWithAddress;
 use NeuronAI\Tests\Utils\PersonWithTags;
+use NeuronAI\Tests\Utils\Tag;
 use PHPUnit\Framework\TestCase;
 
 class JsonSchemaTest extends TestCase
@@ -204,6 +205,43 @@ class JsonSchemaTest extends TestCase
                 ]
             ],
             'required' => ['firstName', 'lastName', 'tags'],
+            'additionalProperties' => false,
+        ], $schema);
+    }
+
+    public function test_array_of_objects_with_attribute()
+    {
+        $class = new class {
+            #[ArrayOf(Tag::class)]
+            public array $tags;
+        };
+
+        $schema = (new JsonSchema())->generate($class::class);
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'tags' => [
+                    'type' => 'array',
+                    'items' => [
+                        '$ref' => '#/definitions/Tag'
+                    ]
+                ]
+            ],
+            'definitions' => [
+                'Tag' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'description' => 'The name of the tag',
+                            'type' => 'string',
+                        ]
+                    ],
+                    'required' => ['name'],
+                    'additionalProperties' => false,
+                ]
+            ],
+            'required' => ['tags'],
             'additionalProperties' => false,
         ], $schema);
     }


### PR DESCRIPTION
While trying Structured Output I tried using a list with the doc-block like this:
```
/**
* @var array<\App\Agent\Models\Tag>
*/
```
I could not get it to work. The problem was I did a comment with an imported class like this:
```
/**
* @var array<Product>
*/
```
And my Phpstorm really wants me to use an import. So thats why I created the ArrayOf attribute. So now it's possible to do this:
```
#[ArrayOf(Product::class)]
public array $products;
```