### PR TITLE
Adding static Message creation

### DIFF
--- a/src/Chat/Messages/CallStatic.php
+++ b/src/Chat/Messages/CallStatic.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace NeuronAI\Chat\Messages;
+
+use NeuronAI\StaticConstructor;
+
+trait CallStatic
+{
+    use StaticConstructor;
+
+    public static function assistant(array|string|int|float|null $content): AssistantMessage
+    {
+        return new AssistantMessage($content);
+    }
+
+    public static function toolCall(array|string|int|float|null $content, array $tools): ToolCallMessage
+    {
+        return new ToolCallMessage($content, $tools);
+    }
+
+    public static function toolCallResult(array $tools): ToolCallResultMessage
+    {
+        return new ToolCallResultMessage($tools);
+    }
+
+    public static function user(array|string|int|float|null $content): UserMessage
+    {
+        return new UserMessage($content);
+    }
+}

--- a/src/Chat/Messages/Message.php
+++ b/src/Chat/Messages/Message.php
@@ -4,6 +4,8 @@ namespace NeuronAI\Chat\Messages;
 
 class Message implements \JsonSerializable
 {
+    use CallStatic;
+
     const ROLE_USER = 'user';
     const ROLE_ASSISTANT = 'assistant';
     const ROLE_MODEL = 'model';


### PR DESCRIPTION
Agents have a static constructor. We can use Agent::make() to instantiate a new class.

After implementing image support, I noticed the syntax used in UserMessage with an image — and it hurt my eyes:
```
$message = (new UserMessage("Describe this image"))
    ->addImage(new Image(
        image: 'https://url_of/image.jpg', 
        type: Image::TYPE_URL
    ));
```
Starting from PHP 8.4, we can omit the outer parentheses, but I was still looking for a cleaner solution.

With the CallStatic trait, we can now simply write:
```
$message = Message::UserMessage("Describe this image")
    ->addImage(Image::make('https://url_of/image.jpg'));
```