### PR TITLE
fix: add nullish operator when tools does not have description

### DIFF
--- a/src/MCP/McpConnector.php
+++ b/src/MCP/McpConnector.php
@@ -40,7 +40,7 @@ class McpConnector
     {
         $tool = Tool::make(
             name: $item['name'],
-            description: $item['description']??''
+            description: $item['description'] ?? ''
         )->setCallable(function (...$args) use ($item) {
             $response = call_user_func([$this->client, 'callTool'], $item['name'], $args);
             $response = $response['result']['content'][0];
@@ -61,7 +61,7 @@ class McpConnector
                 new ToolProperty(
                     $name,
                     $input['type'],
-                    $input['description'],
+                    $input['description'] ?? '',
                     \in_array($name, $item['inputSchema']['required']??[])
                 )
             );


### PR DESCRIPTION
Hello!

I mentioned this bug: https://github.com/inspector-apm/neuron-ai/issues/87

and I have seen the fix from you but it persisted in my local tests, so in order to solve it I have opened this MR with the fix that worked for me, please let me know if I need to do something else to help the project.

stacktrace even after upgrading the project

```
 PHP Warning:  Undefined array key "description" in \vendor\inspector-apm\neuron-ai\src\MCP\McpConnector.php on line 64
PHP Fatal error:  Uncaught TypeError: NeuronAI\Tools\ToolProperty::__construct(): Argument #3 ($description) must be of type string, null given, called in \vendor\inspector-apm\neuron-ai\src\MCP\McpConnector.php on line 61 and defined in \vendor\inspector-apm\neuron-ai\src\Tools\ToolProperty.php:7
```