### PR TITLE
Fix for Gemini response when called in workflow

### DIFF
--- a/src/Providers/Gemini/HandleChat.php
+++ b/src/Providers/Gemini/HandleChat.php
@@ -52,7 +52,7 @@ trait HandleChat
             $response->setUsage(
                 new Usage(
                     $result['usageMetadata']['promptTokenCount'],
-                    $result['usageMetadata']['candidatesTokenCount']
+                    $result['usageMetadata']['candidatesTokenCount'] ?? $result['usageMetadata']['promptTokensDetails'][0]['tokenCount'] ?? 0
                 )
             );
         }


### PR DESCRIPTION
Fix of

Undefined array key "candidatesTokenCount" in this file vendor\inspector-apm\neuron-ai\src\Providers\Gemini\HandleChat.php


Seems when calling Gemini in a workflow defined in https://github.com/inspector-apm/neuron-ai/pull/102 
  it does not include candidatesTokenCount every time 



![image](https://github.com/user-attachments/assets/7d9268d2-df60-46ad-8624-d07fb7da8c75)
