### PR TITLE
refactor platform check to allow doctrine/dbal:^4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
     push:
-        branches: [ "main" ]
+        branches: [ "main","tac" ]
     pull_request:
         branches: [ "main" ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: ['8.2', '8.3', '8.4']
-                dependency-version: [prefer-lowest, prefer-stable]
+                dependency-version: [prefer-highest, prefer-stable]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/src/RAG/VectorStore/Doctrine/SupportedDoctrineVectorStore.php
+++ b/src/RAG/VectorStore/Doctrine/SupportedDoctrineVectorStore.php
@@ -33,6 +33,7 @@ abstract class SupportedDoctrineVectorStore
     {
         return [
             'postgresql',
+            'postgresql120',
             'mysql',
         ];
     }

--- a/src/RAG/VectorStore/Doctrine/VectorType.php
+++ b/src/RAG/VectorStore/Doctrine/VectorType.php
@@ -15,11 +15,15 @@ class VectorType extends Type
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        // getName is deprecated since doctrine/dbal 2.13 see: https://github.com/doctrine/dbal/issues/4749
-        // BUT it is the most stable way to check if the platform is PostgreSQLPlatform in a lot of doctrine versions
-        // so we will use it and add a check for the class name in case it is removed in the future
-        if (! \in_array($platform->getName(), SupportedDoctrineVectorStore::values())) {
-            throw Exception::notSupported('VECTORs not supported by Platform.');
+        $platformClass = get_class($platform);
+
+        $parts = explode('\\', $platformClass);
+        $shortName = end($parts); // e.g., 'PostgreSQLPlatform'
+
+        $shortName =  strtolower(str_replace('Platform', '', $shortName)); // e.g., 'postgresql'
+
+        if (! \in_array($shortName, SupportedDoctrineVectorStore::values())) {
+            throw Exception::notSupported('VECTORs not supported by Platform. ' . $shortName);
         }
 
         if (! isset($column['length'])) {


### PR DESCRIPTION
I wish I know CI better, so we could check all the versions of doctrine during testing.

I believe, though, that this will work for all, as the current code fails with dbal 4.