### PR TITLE
Context Accumulation Fix and New Public API for Advanced Use Cases

### DIFF
--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -68,7 +68,7 @@ class RAG extends Agent
 
         $originalInstructions = $this->instructions();
         $this->notify('rag-instructions-changing', new InstructionsChanging($originalInstructions));
-        $this->setSystemMessage($documents);
+        $this->withDocumentsContext($documents);
         $this->notify('rag-instructions-changed', new InstructionsChanged($originalInstructions, $this->instructions()));
     }
 
@@ -78,7 +78,7 @@ class RAG extends Agent
      * @param array<Document> $documents
      * @return AgentInterface
      */
-    protected function setSystemMessage(array $documents): AgentInterface
+    public function withDocumentsContext(array $documents): AgentInterface
     {
         $beginContextDelimiter = PHP_EOL.PHP_EOL.'# EXTRA INFORMATION AND CONTEXT'.PHP_EOL;
 
@@ -93,6 +93,14 @@ class RAG extends Agent
         }
 
         return $this->withInstructions($newInstructions);
+    }
+
+    /**
+     * @deprecated Use withDocumentsContext instead.
+     */
+    protected function setSystemMessage(array $documents): AgentInterface
+    {
+        return $this->withDocumentsContext($documents);
     }
 
     /**

--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -64,8 +64,6 @@ class RAG extends Agent
         $documents = $this->retrieveDocuments($question);
         $this->notify('rag-vectorstore-result', new VectorStoreResult($question, $documents));
 
-        $documents = $this->applyPostProcessors($question, $documents);
-
         $originalInstructions = $this->instructions();
         $this->notify('rag-instructions-changing', new InstructionsChanging($originalInstructions));
         $this->withDocumentsContext($documents);
@@ -121,7 +119,9 @@ class RAG extends Agent
             $retrievedDocs[\md5($doc->content)] = $doc;
         }
 
-        return \array_values($retrievedDocs);
+        $retrievedDocs = \array_values($retrievedDocs);
+
+        return $this->applyPostProcessors($question, $retrievedDocs);
     }
 
     /**

--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -61,7 +61,7 @@ class RAG extends Agent
     protected function retrieval(Message $question): void
     {
         $this->notify('rag-vectorstore-searching', new VectorStoreSearching($question));
-        $documents = $this->searchDocuments($question->getContent());
+        $documents = $this->retrieveDocuments($question);
         $this->notify('rag-vectorstore-result', new VectorStoreResult($question, $documents));
 
         $documents = $this->applyPostProcessors($question, $documents);
@@ -108,10 +108,10 @@ class RAG extends Agent
      *
      * @return array<Document>
      */
-    private function searchDocuments(string $question): array
+    public function retrieveDocuments(Message $question): array
     {
         $docs = $this->resolveVectorStore()->similaritySearch(
-            $this->resolveEmbeddingsProvider()->embedText($question)
+            $this->resolveEmbeddingsProvider()->embedText($question->getContent())
         );
 
         $retrievedDocs = [];

--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -80,14 +80,19 @@ class RAG extends Agent
      */
     protected function setSystemMessage(array $documents): AgentInterface
     {
-        $context = '';
+        $beginContextDelimiter = PHP_EOL.PHP_EOL.'# EXTRA INFORMATION AND CONTEXT'.PHP_EOL;
+
+        // Remove the old context
+        $newInstructions = preg_replace('/'.$beginContextDelimiter.'.*/s', '', $this->instructions());
+
+        // Add the new context
+        $newInstructions .= $beginContextDelimiter;
+
         foreach ($documents as $document) {
-            $context .= $document->content.' ';
+            $newInstructions .= $document->content.PHP_EOL;
         }
 
-        return $this->withInstructions(
-            $this->instructions().PHP_EOL.PHP_EOL."# EXTRA INFORMATION AND CONTEXT".PHP_EOL.$context
-        );
+        return $this->withInstructions($newInstructions);
     }
 
     /**


### PR DESCRIPTION
### Bug Fix: Context Accumulation
Fixed critical issue where multiple `answer()` calls caused infinite growth of system instructions. Previously, each call would append context to existing instructions without removing the old one leading to malformed system prompts with duplicate context sections.

### New Public API for Advanced Use Cases
Exposed two public methods to enable flexible document retrieval and context management:
- `retrieveDocuments(Message $question): array`
- `withDocumentsContext(array $documents): AgentInterface`

These methods enable scenarios such as:

```php
// Mix contexts from multiple specialized RAG systems
$technicalDocs = $ragTechnical->retrieveDocuments($question);
$businessDocs = $ragBusiness->retrieveDocuments($question);
$legalDocs = $ragLegal->retrieveDocuments($question);

// Combine and send to orchestrator agent
$allDocs = array_merge($technicalDocs, $businessDocs, $legalDocs);
$orchestrator->withDocumentsContext($allDocs)->chat($question);
```