### PR TITLE
Improve workflow observability

### DIFF
--- a/src/Observability/Events/WorkflowEnd.php
+++ b/src/Observability/Events/WorkflowEnd.php
@@ -6,7 +6,7 @@ use NeuronAI\Chat\Messages\Message;
 
 class WorkflowEnd
 {
-    public function __construct(public Message $lastReply)
+    public function __construct(public ?Message $lastReply)
     {
     }
 }

--- a/src/Observability/Events/WorkflowNodeEnd.php
+++ b/src/Observability/Events/WorkflowNodeEnd.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace NeuronAI\Observability\Events;
+
+use NeuronAI\Chat\Messages\Message;
+
+class WorkflowNodeEnd
+{
+    public function __construct(
+        public string $node,
+        public ?Message $lastReply,
+    ) {
+    }
+}

--- a/src/Observability/Events/WorkflowNodeStart.php
+++ b/src/Observability/Events/WorkflowNodeStart.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NeuronAI\Observability\Events;
+
+use NeuronAI\Chat\Messages\Message;
+
+class WorkflowNodeStart
+{
+    /**
+     * @param string $node
+     * @param Message[] $messages
+     */
+    public function __construct(
+        public string $node,
+        public array $messages,
+    ) {
+    }
+}

--- a/src/Observability/LogObserver.php
+++ b/src/Observability/LogObserver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeuronAI\Observability;
 
+use NeuronAI\Chat\Messages\Message;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
@@ -46,14 +47,12 @@ class LogObserver implements \SplObserver
             Events\Deserialized::class => [
                 'class' => $data->class
             ],
-            Events\Extracting::class => [
-                'message' => $data->message->jsonSerialize(),
-            ],
             Events\Extracted::class => [
                 'message' => $data->message->jsonSerialize(),
                 'schema' => $data->schema,
                 'json' => $data->json,
             ],
+            Events\Extracting::class,
             Events\InferenceStart::class,
             Events\MessageSaving::class,
             Events\MessageSaved::class => [
@@ -89,6 +88,20 @@ class LogObserver implements \SplObserver
             Events\VectorStoreResult::class => [
                 'question' => $data->question->jsonSerialize(),
                 'documents' => $data->documents,
+            ],
+            Events\WorkflowStart::class => [
+                'executionList' => $data->executionList,
+            ],
+            Events\WorkflowNodeStart::class => [
+                'node' => $data->node,
+                'input' => array_map(fn (Message $message) => $message->jsonSerialize(), $data->messages),
+            ],
+            Events\WorkflowNodeEnd::class => [
+                'node' => $data->node,
+                'lastReply' => $data->lastReply?->jsonSerialize(),
+            ],
+            Events\WorkflowEnd::class => [
+                'lastReply' => $data->lastReply?->jsonSerialize(),
             ],
             default => [],
         };

--- a/src/Workflow/Workflow.php
+++ b/src/Workflow/Workflow.php
@@ -7,6 +7,8 @@ namespace NeuronAI\Workflow;
 use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Exceptions\StateGraphError;
 use NeuronAI\Observability\Events\WorkflowEnd;
+use NeuronAI\Observability\Events\WorkflowNodeEnd;
+use NeuronAI\Observability\Events\WorkflowNodeStart;
 use NeuronAI\Observability\Events\WorkflowStart;
 use NeuronAI\Observability\Observable;
 use NeuronAI\StaticConstructor;
@@ -51,8 +53,12 @@ class Workflow implements SplSubject
 
             $this->attachObservers($node);
 
+            $this->notify('workflow-node-start', new WorkflowNodeStart($item, $input));
+
             $lastReply = $node->execute($input);
             $this->replies[$item] = [$lastReply];
+
+            $this->notify('workflow-node-end', new WorkflowNodeEnd($item, $lastReply));
         }
 
         $this->notify('workflow-end', new WorkflowEnd($lastReply));


### PR DESCRIPTION
This PR improves the observability of the Workflow by adding the `workflow-node-start` and `workflow-node-end` events and properly serializing the events data.