### PR TITLE
Fix json with incorrectly formatted structure

### DIFF
--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -79,11 +79,6 @@ class OpenAI implements AIProviderInterface
                 'function' => [
                     'name' => $tool->getName(),
                     'description' => $tool->getDescription(),
-                    'parameters' => [
-                        'type' => 'object',
-                        'properties' => new \stdClass(),
-                        'required' => [],
-                    ],
                 ]
             ];
 


### PR DESCRIPTION
Fix json with incorrectly formatted structure for when it has no parameters