### PR TITLE
SentenceTextSplitter and SplitterInterface for pluggable text splitting

### DIFF
--- a/src/RAG/DataLoader/AbstractDataLoader.php
+++ b/src/RAG/DataLoader/AbstractDataLoader.php
@@ -2,11 +2,21 @@
 
 namespace NeuronAI\RAG\DataLoader;
 
+use NeuronAI\RAG\Splitter\DelimiterTextSplitter;
+use NeuronAI\RAG\Splitter\SplitterInterface;
+
 abstract class AbstractDataLoader implements DataLoaderInterface
 {
-    protected int $maxLength = 1000;
-    protected string $separator = '.';
-    protected int $wordOverlap = 0;
+    protected SplitterInterface $splitter;
+
+    public function __construct()
+    {
+        $this->splitter = new DelimiterTextSplitter(
+            maxLength: 1000,
+            separator: '.',
+            wordOverlap: 0
+        );
+    }
 
     public static function for(...$arguments): static
     {
@@ -14,21 +24,9 @@ abstract class AbstractDataLoader implements DataLoaderInterface
         return new static(...$arguments);
     }
 
-    public function withMaxLength(int $maxLength): DataLoaderInterface
+    public function withSplitter(SplitterInterface $splitter): DataLoaderInterface
     {
-        $this->maxLength = $maxLength;
-        return $this;
-    }
-
-    public function withSeparator(string $separator): DataLoaderInterface
-    {
-        $this->separator = $separator;
-        return $this;
-    }
-
-    public function withOverlap(int $overlap): DataLoaderInterface
-    {
-        $this->wordOverlap = $overlap;
+        $this->splitter = $splitter;
         return $this;
     }
 }

--- a/src/RAG/DataLoader/FileDataLoader.php
+++ b/src/RAG/DataLoader/FileDataLoader.php
@@ -13,6 +13,7 @@ class FileDataLoader extends AbstractDataLoader
 
     public function __construct(protected string $path, array $readers = [])
     {
+        parent::__construct();
         $this->setReaders($readers);
     }
 
@@ -75,12 +76,7 @@ class FileDataLoader extends AbstractDataLoader
             closedir($handle);
         }
 
-        return DocumentSplitter::splitDocuments(
-            $documents,
-            $this->maxLength,
-            $this->separator,
-            $this->wordOverlap
-        );
+        return $this->splitter->splitDocuments($documents);
     }
 
     /**

--- a/src/RAG/DataLoader/StringDataLoader.php
+++ b/src/RAG/DataLoader/StringDataLoader.php
@@ -8,15 +8,11 @@ class StringDataLoader extends AbstractDataLoader
 {
     public function __construct(protected string $content)
     {
+        parent::__construct();
     }
 
     public function getDocuments(): array
     {
-        return DocumentSplitter::splitDocument(
-            new Document($this->content),
-            $this->maxLength,
-            $this->separator,
-            $this->wordOverlap
-        );
+        return $this->splitter->splitDocument(new Document($this->content));
     }
 }

--- a/src/RAG/Splitter/SplitterInterface.php
+++ b/src/RAG/Splitter/SplitterInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NeuronAI\RAG\Splitter;
+
+use NeuronAI\RAG\Document;
+
+interface SplitterInterface
+{
+    /**
+     * @param  Document  $document
+     * @return array<Document>
+     */
+    public function splitDocument(Document $document): array;
+
+    /**
+     * @param  array<Document>  $documents
+     * @return array<Document>
+     */
+    public function splitDocuments(array $documents): array;
+}

--- a/tests/DataLoaderTest.php
+++ b/tests/DataLoaderTest.php
@@ -3,8 +3,6 @@
 namespace NeuronAI\Tests;
 
 use NeuronAI\RAG\DataLoader\StringDataLoader;
-use NeuronAI\RAG\Document;
-use NeuronAI\RAG\DataLoader\DocumentSplitter;
 use PHPUnit\Framework\TestCase;
 
 class DataLoaderTest extends TestCase
@@ -15,19 +13,5 @@ class DataLoaderTest extends TestCase
         $this->assertCount(1, $documents);
         $this->assertEquals('test', $documents[0]->content);
         $this->assertEquals(\hash('sha256', 'test'), $documents[0]->hash);
-    }
-
-    public function test_split_long_text()
-    {
-        $doc = new Document(file_get_contents(__DIR__.'/stubs/long-text.txt'));
-
-        $documents = DocumentSplitter::splitDocument($doc);
-        $this->assertCount(7, $documents);
-
-        $documents = DocumentSplitter::splitDocument($doc, 500);
-        $this->assertCount(14, $documents);
-
-        $documents = DocumentSplitter::splitDocument($doc, 1000, "\n");
-        $this->assertCount(12, $documents);
     }
 }

--- a/tests/Splitter/DelimiterTextSplitterTest.php
+++ b/tests/Splitter/DelimiterTextSplitterTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\RAG\Splitter;
+
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\Splitter\DelimiterTextSplitter;
+use PHPUnit\Framework\TestCase;
+
+class DelimiterTextSplitterTest extends TestCase
+{
+    public function test_split_long_text()
+    {
+        $doc = new Document(file_get_contents(__DIR__.'/../stubs/long-text.txt'));
+
+        $splitter = new DelimiterTextSplitter();
+        $documents = $splitter->splitDocument($doc);
+        $this->assertCount(7, $documents);
+
+        $splitter = new DelimiterTextSplitter(maxLength: 500);
+        $documents = $splitter->splitDocument($doc);
+        $this->assertCount(14, $documents);
+
+        $splitter = new DelimiterTextSplitter(maxLength: 1000, separator: "\n");
+        $documents = $splitter->splitDocument($doc);
+        $this->assertCount(12, $documents);
+    }
+}

--- a/tests/Splitter/SentenceTextSplitterTest.php
+++ b/tests/Splitter/SentenceTextSplitterTest.php
@@ -85,6 +85,7 @@ class SentenceTextSplitterTest extends TestCase
         ];
 
         $allContent = implode(' ', array_map(fn($c) => $c->content, $result));
+
         foreach ($sentences as $sentence) {
             $this->assertStringContainsString($sentence, $allContent, "The sentence '$sentence' is not present");
             // Verify the sentence appears exactly once
@@ -104,9 +105,12 @@ class SentenceTextSplitterTest extends TestCase
     public function test_chunking_base(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+
         $text = "First sentence. Second sentence. Third sentence.";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         $this->assertCount(1, $result);
         $this->assertStringContainsString('First sentence. Second sentence. Third sentence.', $result[0]->content);
     }
@@ -114,12 +118,17 @@ class SentenceTextSplitterTest extends TestCase
     public function test_chunking_with_overlap(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 2);
+
         $text = "One two three four five six seven eight nine ten. Eleven twelve thirteen fourteen fifteen.";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         $this->assertGreaterThan(1, count($result));
+
         $firstChunkWords = preg_split('/\s+/u', trim($result[0]->content));
         $secondChunkWords = preg_split('/\s+/u', trim($result[1]->content));
+
         $this->assertEquals(
             array_slice($firstChunkWords, -2),
             array_slice($secondChunkWords, 0, 2)
@@ -129,10 +138,14 @@ class SentenceTextSplitterTest extends TestCase
     public function test_long_sentence_is_split(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 5, overlapWords: 0);
+
         $text = "one two three four five six seven eight nine ten";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         $this->assertGreaterThan(1, count($result));
+
         foreach ($result as $chunk) {
             $words = preg_split('/\s+/u', trim($chunk->content));
             $this->assertLessThanOrEqual(5, count($words));
@@ -142,37 +155,49 @@ class SentenceTextSplitterTest extends TestCase
     public function test_paragraphs_not_split(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+
         $text = "First paragraph.\n\nSecond paragraph which is very long and contains many words and exceeds the chunk limit. Third paragraph.";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         $this->assertStringContainsString('First paragraph.', $result[0]->content);
+        
         $found = false;
         foreach ($result as $chunk) {
             if (strpos($chunk->content, 'Second paragraph') !== false) {
                 $found = true;
             }
         }
+
         $this->assertTrue($found, 'The second paragraph must be present in at least one chunk.');
+
         $found = false;
         foreach ($result as $chunk) {
             if (strpos($chunk->content, 'Third paragraph.') !== false) {
                 $found = true;
             }
         }
+
         $this->assertTrue($found, 'The third paragraph must be present in at least one chunk.');
     }
 
     public function test_chunking_with_short_and_long_sentences(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 6, overlapWords: 0);
+
         $text = "Short. This is a very long sentence that exceeds the chunk limit. End.";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         foreach ($result as $chunk) {
             $words = preg_split('/\s+/u', trim($chunk->content));
             $this->assertLessThanOrEqual(6, count($words));
         }
+
         $allContent = implode(' ', array_map(fn($c) => $c->content, $result));
+
         $this->assertStringContainsString('Short.', $allContent);
         $this->assertStringContainsString('End.', $allContent);
     }
@@ -180,18 +205,24 @@ class SentenceTextSplitterTest extends TestCase
     public function test_empty_text(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+
         $text = "   ";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         $this->assertCount(0, $result);
     }
 
     public function test_single_sentence(): void
     {
         $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+
         $text = "Only one sentence.";
         $document = new Document($text);
+
         $result = $splitter->splitDocument($document);
+
         $this->assertCount(1, $result);
         $this->assertEquals('Only one sentence.', trim($result[0]->content));
     }

--- a/tests/Splitter/SentenceTextSplitterTest.php
+++ b/tests/Splitter/SentenceTextSplitterTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\RAG\Splitter;
+
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\Splitter\SentenceTextSplitter;
+use PHPUnit\Framework\TestCase;
+
+class SentenceTextSplitterTest extends TestCase
+{
+    public function test_split_document_with_overlap(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 2);
+
+        $text = "This is a longer text that should be split into multiple chunks. " .
+                "This is the second sentence that should appear in two chunks. " .
+                "This is the third sentence that completes the text.";
+        
+        $document = new Document($text);
+        $document->sourceType = 'test';
+        $document->sourceName = 'test.txt';
+
+        $result = $splitter->splitDocument($document);
+
+        $this->assertGreaterThan(1, count($result));
+        
+        // Verifica che l'overlap sia presente
+        $firstChunkWords = explode(' ', $result[0]->content);
+        $secondChunkWords = explode(' ', $result[1]->content);
+        
+        $this->assertEquals(
+            array_slice($firstChunkWords, -2),
+            array_slice($secondChunkWords, 0, 2)
+        );
+    }
+
+    public function test_split_document_preserves_metadata(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 2);
+
+        $text = "Test document.";
+        $document = new Document($text);
+        $document->sourceType = 'test';
+        $document->sourceName = 'test.txt';
+
+        $result = $splitter->splitDocument($document);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('test', $result[0]->sourceType);
+        $this->assertEquals('test.txt', $result[0]->sourceName);
+        $this->assertEquals(0, $result[0]->chunkNumber);
+    }
+
+    public function test_invalid_overlap_configuration(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new SentenceTextSplitter(maxWords: 10, overlapWords: 10);
+    }
+
+    public function test_split_document_without_overlap(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+        
+        $text = "This is the first sentence. This is the second sentence. This is the third sentence.";
+        $document = new Document($text);
+        $document->sourceType = 'test';
+        $document->sourceName = 'test.txt';
+
+        $result = $splitter->splitDocument($document);
+
+        // Verify there are exactly 2 chunks
+        $this->assertCount(2, $result);
+
+        // Verify no chunk exceeds the word limit
+        foreach ($result as $chunk) {
+            $words = preg_split('/\s+/u', trim($chunk->content));
+            $this->assertLessThanOrEqual(10, count($words), 'Chunk exceeds word limit');
+        }
+
+        // Verify all sentences are present exactly once
+        $sentences = [
+            'This is the first sentence.',
+            'This is the second sentence.',
+            'This is the third sentence.'
+        ];
+
+        $allContent = implode(' ', array_map(fn($c) => $c->content, $result));
+        foreach ($sentences as $sentence) {
+            $this->assertStringContainsString($sentence, $allContent, "The sentence '$sentence' is not present");
+            // Verify the sentence appears exactly once
+            $this->assertEquals(1, substr_count($allContent, $sentence), "The sentence '$sentence' appears more than once");
+        }
+
+        // Verify there is no overlap between chunks
+        $firstChunkWords = preg_split('/\s+/u', trim($result[0]->content));
+        $secondChunkWords = preg_split('/\s+/u', trim($result[1]->content));
+
+        // Last words of first chunk should not be the first words of second chunk
+        $lastWordsOfFirst = array_slice($firstChunkWords, -2);
+        $firstWordsOfSecond = array_slice($secondChunkWords, 0, 2);
+        $this->assertNotEquals($lastWordsOfFirst, $firstWordsOfSecond, 'Overlap present when it should not be');
+    }
+
+    public function test_chunking_base(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+        $text = "First sentence. Second sentence. Third sentence.";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('First sentence. Second sentence. Third sentence.', $result[0]->content);
+    }
+
+    public function test_chunking_with_overlap(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 2);
+        $text = "One two three four five six seven eight nine ten. Eleven twelve thirteen fourteen fifteen.";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        $this->assertGreaterThan(1, count($result));
+        $firstChunkWords = preg_split('/\s+/u', trim($result[0]->content));
+        $secondChunkWords = preg_split('/\s+/u', trim($result[1]->content));
+        $this->assertEquals(
+            array_slice($firstChunkWords, -2),
+            array_slice($secondChunkWords, 0, 2)
+        );
+    }
+
+    public function test_long_sentence_is_split(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 5, overlapWords: 0);
+        $text = "one two three four five six seven eight nine ten";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        $this->assertGreaterThan(1, count($result));
+        foreach ($result as $chunk) {
+            $words = preg_split('/\s+/u', trim($chunk->content));
+            $this->assertLessThanOrEqual(5, count($words));
+        }
+    }
+
+    public function test_paragraphs_not_split(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+        $text = "First paragraph.\n\nSecond paragraph which is very long and contains many words and exceeds the chunk limit. Third paragraph.";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        $this->assertStringContainsString('First paragraph.', $result[0]->content);
+        $found = false;
+        foreach ($result as $chunk) {
+            if (strpos($chunk->content, 'Second paragraph') !== false) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'The second paragraph must be present in at least one chunk.');
+        $found = false;
+        foreach ($result as $chunk) {
+            if (strpos($chunk->content, 'Third paragraph.') !== false) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, 'The third paragraph must be present in at least one chunk.');
+    }
+
+    public function test_chunking_with_short_and_long_sentences(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 6, overlapWords: 0);
+        $text = "Short. This is a very long sentence that exceeds the chunk limit. End.";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        foreach ($result as $chunk) {
+            $words = preg_split('/\s+/u', trim($chunk->content));
+            $this->assertLessThanOrEqual(6, count($words));
+        }
+        $allContent = implode(' ', array_map(fn($c) => $c->content, $result));
+        $this->assertStringContainsString('Short.', $allContent);
+        $this->assertStringContainsString('End.', $allContent);
+    }
+
+    public function test_empty_text(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+        $text = "   ";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        $this->assertCount(0, $result);
+    }
+
+    public function test_single_sentence(): void
+    {
+        $splitter = new SentenceTextSplitter(maxWords: 10, overlapWords: 0);
+        $text = "Only one sentence.";
+        $document = new Document($text);
+        $result = $splitter->splitDocument($document);
+        $this->assertCount(1, $result);
+        $this->assertEquals('Only one sentence.', trim($result[0]->content));
+    }
+}


### PR DESCRIPTION
This PR introduces a new `SplitterInterface` to fully decouple text-splitting from our data loaders and expose a simple, pluggable API for any chunking strategy.


### What’s changed

- `DelimiterTextSplitter` (formerly `DocumentSplitter`) now implements `SplitterInterface` and lives under `RAG\Splitter`

- `AbstractDataLoader` defaults to `DelimiterTextSplitter` and gains a `withSplitter()` method for injecting custom splitters

- `FileDataLoader` & `StringDataLoader` now delegate all splitting to the configured `SplitterInterface` instead of using static helpers

- **SentenceTextSplitter** added: a new strategy that preserves sentence/paragraph boundaries, chunks by word count, and supports overlap

### Next steps
With `SplitterInterface` in place it’s trivial to add more built-in splitters, for example:

- `RecursiveCharacterTextSplitter` (LangChain style, trying \n\n, \n, , `` until chunks fit)

- `HTMLHeaderTextSplitter` / HTMLSectionSplitter for splitting on HTML tags (e.g. h1–h6, section)

- `MarkdownHeaderTextSplitter` for splitting on Markdown headings (#, ##, etc.)