### PR TITLE
Fixed pinecone api client version

### DIFF
--- a/src/RAG/VectorStore/PineconeVectorStore.php
+++ b/src/RAG/VectorStore/PineconeVectorStore.php
@@ -23,7 +23,7 @@ class PineconeVectorStore implements VectorStoreInterface
         string $key,
         protected string $indexUrl,
         protected int $topK = 4,
-        string $version = '2025-01',
+        string $version = '2025-04',
         protected string $namespace = '__default__'
     ) {
         $this->client = new Client([


### PR DESCRIPTION
I recently ran into a 400 Bad Request error when using PineconeVectorStore:

```
Client error: POST https://<index>.pinecone.io/vectors/upsert resulted in a 400 Bad Request response:
{"code":3,"message":"Use of namespace='__default__' is not allowed in API versions prior to 2025-04","details":[]}
```

To fix this, I bumped the constructor’s $version default from “2025-01” to “2025-04”.