### PR TITLE
Array property length constraint support

### DIFF
--- a/src/Exceptions/ArrayPropertyException.php
+++ b/src/Exceptions/ArrayPropertyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NeuronAI\Exceptions;
+
+class ArrayPropertyException extends NeuronException
+{
+}

--- a/src/Tools/ArrayProperty.php
+++ b/src/Tools/ArrayProperty.php
@@ -11,6 +11,8 @@ class ArrayProperty implements ToolPropertyInterface
         protected string $description,
         protected bool $required = false,
         protected ?ToolPropertyInterface $items = null,
+        protected ?int $minItems = null,
+        protected ?int $maxItems = null,
     ) {
     }
 
@@ -34,6 +36,14 @@ class ArrayProperty implements ToolPropertyInterface
 
         if (!empty($this->items)) {
             $schema['items'] = $this->items->getJsonSchema();
+        }
+
+        if(!empty($this->minItems)) {
+            $schema['minItems'] = $this->minItems;
+        }
+
+        if(!empty($this->maxItems)) {
+            $schema['maxItems'] = $this->maxItems;
         }
 
         return $schema;

--- a/src/Tools/ArrayProperty.php
+++ b/src/Tools/ArrayProperty.php
@@ -2,10 +2,15 @@
 
 namespace NeuronAI\Tools;
 
+use NeuronAI\Exceptions\ArrayPropertyException;
+
 class ArrayProperty implements ToolPropertyInterface
 {
     protected PropertyType $type = PropertyType::ARRAY;
 
+    /**
+     * @throws ArrayPropertyException
+     */
     public function __construct(
         protected string $name,
         protected string $description,
@@ -14,6 +19,7 @@ class ArrayProperty implements ToolPropertyInterface
         protected ?int $minItems = null,
         protected ?int $maxItems = null,
     ) {
+        $this->validateConstraints();
     }
 
     public function jsonSerialize(): array
@@ -38,11 +44,11 @@ class ArrayProperty implements ToolPropertyInterface
             $schema['items'] = $this->items->getJsonSchema();
         }
 
-        if(!empty($this->minItems)) {
+        if (!empty($this->minItems)) {
             $schema['minItems'] = $this->minItems;
         }
 
-        if(!empty($this->maxItems)) {
+        if (!empty($this->maxItems)) {
             $schema['maxItems'] = $this->maxItems;
         }
 
@@ -72,5 +78,25 @@ class ArrayProperty implements ToolPropertyInterface
     public function getItems(): ?ToolPropertyInterface
     {
         return $this->items;
+    }
+
+    /**
+     * @throws ArrayPropertyException
+     */
+    protected function validateConstraints(): void
+    {
+        if ($this->minItems !== null && $this->minItems < 0) {
+            throw new ArrayPropertyException("minItems must be >= 0, got {$this->minItems}");
+        }
+
+        if ($this->maxItems !== null && $this->maxItems < 0) {
+            throw new ArrayPropertyException("maxItems must be >= 0, got {$this->maxItems}");
+        }
+
+        if ($this->minItems !== null && $this->maxItems !== null && $this->minItems > $this->maxItems) {
+            throw new ArrayPropertyException(
+                "minItems ({$this->minItems}) cannot be greater than maxItems ({$this->maxItems})"
+            );
+        }
     }
 }

--- a/tests/ArrayPropertyTest.php
+++ b/tests/ArrayPropertyTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace NeuronAI\Tests;
+
+use NeuronAI\Exceptions\ArrayPropertyException;
+use NeuronAI\Tools\ArrayProperty;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\ToolProperty;
+use PHPUnit\Framework\TestCase;
+
+class ArrayPropertyTest extends TestCase
+{
+    public function test_json_schema_contains_min_and_max_items()
+    {
+        $arrayProp = new ArrayProperty(
+            name :"array_prop",
+            description: "array prop description",
+            required: true,
+            items: new ToolProperty(
+                name :"array_item",
+                type: PropertyType::STRING,
+                description: "array item description",
+                required: true,
+            ),
+            minItems: 1,
+            maxItems: 10
+        );
+
+        $expectedJsonSchema = [
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+                'description' => 'array item description',
+            ],
+            'minItems' => 1,
+            'maxItems' => 10,
+            'description' => "array prop description",
+        ];
+
+        $this->assertEquals($expectedJsonSchema, $arrayProp->getJsonSchema());
+
+    }
+
+    public function test_min_items_equals_max_items_is_valid()
+    {
+        $arrayProp = new ArrayProperty(
+            name :"array_prop",
+            description: "array prop description",
+            required: true,
+            items: new ToolProperty(
+                name :"array_item",
+                type: PropertyType::STRING,
+                description: "array item description",
+                required: true,
+            ),
+            minItems: 5,
+            maxItems: 5
+        );
+
+        $expectedJsonSchema = [
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+                'description' => 'array item description',
+            ],
+            'minItems' => 5,
+            'maxItems' => 5,
+            'description' => "array prop description",
+        ];
+
+        $this->assertEquals($expectedJsonSchema, $arrayProp->getJsonSchema());
+    }
+
+    public function test_array_property_minmax_items_null()
+    {
+        $arrayProp = new ArrayProperty(
+            name: "array_prop",
+            description: "array prop description",
+            items: new ToolProperty(
+                name: "array_item",
+                type: PropertyType::STRING,
+                description: "array item description",
+                required: true,
+            ),
+        );
+
+        $schema = $arrayProp->getJsonSchema();
+
+        $this->assertArrayNotHasKey('minItems', $schema);
+        $this->assertArrayNotHasKey('maxItems', $schema);
+    }
+
+    public function test_min_items_cannot_be_negative()
+    {
+        $this->expectException(ArrayPropertyException::class);
+        $this->expectExceptionMessage('minItems must be >= 0, got -1');
+
+        $arrayProp = new ArrayProperty(
+            name :"array_prop",
+            description: "array prop description",
+            items: new ToolProperty(
+                name :"array_item",
+                type: PropertyType::STRING,
+                description: "array item description",
+                required: true,
+            ),
+            minItems: -1,
+            maxItems: 10
+        );
+    }
+
+    public function test_max_items_cannot_be_negative()
+    {
+        $this->expectException(ArrayPropertyException::class);
+        $this->expectExceptionMessage('maxItems must be >= 0, got -1');
+
+        $arrayProp = new ArrayProperty(
+            name :"array_prop",
+            description: "array prop description",
+            items: new ToolProperty(
+                name :"array_item",
+                type: PropertyType::STRING,
+                description: "array item description",
+                required: true,
+            ),
+            minItems: 0,
+            maxItems: -1
+        );
+    }
+
+    public function test_min_items_cannot_be_greater_than_max_items()
+    {
+        $this->expectException(ArrayPropertyException::class);
+        $this->expectExceptionMessage('minItems (10) cannot be greater than maxItems (9)');
+
+        $arrayProp = new ArrayProperty(
+            name :"array_prop",
+            description: "array prop description",
+            items: new ToolProperty(
+                name :"array_item",
+                type: PropertyType::STRING,
+                description: "array item description",
+                required: true,
+            ),
+            minItems: 10,
+            maxItems: 9
+        );
+    }
+}


### PR DESCRIPTION
# Array property length constraint support

⚠️ Branch Requirement

- [x] I confirm this PR targets the develop branch

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Description

### What does this PR do?

Adds support for length constraints (`minItems` and `maxItems`) in the `ArrayProperty` class, in accordance with JSON Schema specifications.

### Why is this change needed?

Allows setting minimum and maximum size limits on arrays, improving compliance with JSON Schema standards and enhancing robustness of array property validation.

> [!NOTE]
> These constraints do not enforce strict validation on the input data themselves but serve as guidelines to the LLM, helping it generate responses that conform to the expected structure. Actual validation should still be implemented as needed on the receiving end.

### How does this change should be used and documented?

Documentation should be updated to reflect the addition of `minItems` and `maxItems` parameters in the `ArrayProperty` constructor.

#### Suggestion:

[[...]](https://docs.neuron-ai.dev/tools#arrayproperty) Additionally, it supports length constraints through `minItems` and `maxItems`, allowing you to enforce the minimum and maximum number of elements in the array.

In the example below, we define an array of strings that must contain at least 1 and at most 10 items:

```php
$arrayProp = new ArrayProperty(
    name: "tags",
    description: "List of tags associated with the item",
    required: true,
    items: new ToolProperty(
        name: "tag",
        type: PropertyType::STRING,
        description: "A single tag",
        required: true
    ),
    minItems: 1,
    maxItems: 10
);
```

This ensures that the input will be a non-empty list of strings, with no more than 10 entries, improving validation robustness and making your tool inputs more precise.

This is not

## Testing

- [x] I have tested this change locally

- [x] I have added/updated unit tests where appropriate

- [x] All existing tests pass

## Breaking Changes

- [x] No breaking changes

- [ ] Yes, this PR introduces breaking changes (explain below)

## Documentation

- [ ]No documentation changes needed

- [ ] I have updated relevant documentation

- [ ] Documentation will be updated in a separate PR

- [x] New documentation needs to be created

## Checklist

- [x] My code follows the project's coding standards (PHPStan)

- [x] I have performed a self-review of my code

- [x] My changes generate no new warnings or errors

- [x] My commit messages are clear and descriptive

- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

I deliberately avoid providing getters and setters to keep the tool definition simple and straightforward.

Please feel free to provide feedback or suggestions on the implementation or associated documentation.

