### PR TITLE
Fixed bug in OpenAI stream with multiple tool_calls

### DIFF
--- a/src/Providers/OpenAI/HandleStream.php
+++ b/src/Providers/OpenAI/HandleStream.php
@@ -95,7 +95,9 @@ trait HandleStream
      */
     protected function composeToolCalls(array $line, array $toolCalls): array
     {
-        foreach ($line['choices'][0]['delta']['tool_calls'] as $index => $call) {
+        foreach ($line['choices'][0]['delta']['tool_calls'] as $call) {
+            $index = $call['index'];
+
             if (!\array_key_exists($index, $toolCalls)) {
                 if ($name = $call['function']['name'] ?? null) {
                     $toolCalls[$index]['function'] = ['name' => $name, 'arguments' => ''];


### PR DESCRIPTION
When using `Agent::stream()` with the OpenAI provider and the model generates multiple tool_calls, the method `NeuronAI\Providers\OpenAI\HandleStream::composeToolCalls()` concatenates the calls because it uses the foreach index instead of the index field returned by the API.
The result is an arguments field containing two (or more) adjacent JSON objects.

Steps to reproduce:

```
<?php

// examples/example1.php

require_once __DIR__ . '/../vendor/autoload.php';

use NeuronAI\Agent;
use NeuronAI\Chat\Messages\UserMessage;
use NeuronAI\Providers\OpenAI\OpenAI;
use NeuronAI\Tools\PropertyType;
use NeuronAI\Tools\Tool;
use NeuronAI\Tools\ToolProperty;

$provider = new OpenAI(
    key: 'OPENAI_API_KEY',
    model: 'gpt-4o-mini',
);

$searchTool = Tool::make('search', 'Search information for a given topic')
    ->addProperty(new ToolProperty(
        name: 'topic',
        type: PropertyType::STRING,
        description: 'A topic',
        required: true
    ))
    ->setCallable(function (string $topic): string {
        echo "search($topic)\n";
        return "$topic is a good artist";
    });

$agent = Agent::make()
    ->setAiProvider($provider)
    ->withInstructions('Answer only and exclusively with the information you have found')
    ->addTool($searchTool);

$response = $agent->stream(new UserMessage("Can you tell me about Miles Davis and John Coltrane?"));

foreach ($response as $chunk) {
    echo $chunk;
}

echo "\n";
```

Adding a `print_r($toolCallMessage);` in `HandleStream.php:31` produces:

```
NeuronAI\Chat\Messages\ToolCallMessage Object
(
    ...
    [meta] => Array
        (
            [tool_calls] => Array
                (
                    [0] => Array
                        (
                            [function] => Array
                                (
                                    [name] => search
                                    [arguments] => {"topic": "Miles Davis biography and career"}{"topic": "John Coltrane biography and career"}
                                )
                            [id] => call_Qg7d0eyoLGJDt0KVfx3RqVcp
                            [type] => function
                        )
                )
        )
    ...
)
Segmentation fault (core dumped)
```

`meta['tool_calls'][0]['function']['arguments']` is malformed because adjacent JSON objects were concatenated.

The fix uses the index field supplied by the OpenAI API, preventing concatenation and producing valid JSON.
