### PR TITLE
Generate agents from artisan commands.

### DIFF
--- a/src/Console/Commands/AgentMakeCommand.php
+++ b/src/Console/Commands/AgentMakeCommand.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+
+class AgentMakeCommand extends GeneratorCommand
+{
+    protected $name = 'make:agent';
+    
+    protected $description = 'Create a new AI agent class';
+    
+    protected $type = 'Agent';
+
+    /**
+     * Get the stub file for the generator.
+     */
+    protected function getStub(): string
+    {
+        return __DIR__ . '/../stubs/agent.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $this->option('path') 
+            ? $rootNamespace . '\\' . str_replace('/', '\\', $this->option('path'))
+            : $rootNamespace . '\\Agents';
+    }
+
+    /**
+     * Build the class with the given name.
+     */
+    protected function buildClass($name): string
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceNamespace($stub, $name)
+                    ->replaceClass($stub, $name)
+                    ->replaceProvider($stub)
+                    ->replaceInstructions($stub)
+                    ->replaceTools($stub);
+    }
+
+    /**
+     * Replace the provider implementation in the stub.
+     */
+    protected function replaceProvider(&$stub): static
+    {
+        $provider = $this->option('provider');
+        
+        if (!$provider) {
+            $stub = str_replace('DummyProviderImport', '', $stub);
+            $stub = str_replace(
+                'DummyProviderImplementation', 
+                '// TODO: Configure your AI provider here' . PHP_EOL . 
+                '        // Example: return OpenAIProvider::make();',
+                $stub
+            );
+        } else {
+            $providerConfig = $this->getProviderConfig($provider);
+            $stub = str_replace('DummyProviderImport', $providerConfig['import'], $stub);
+            $stub = str_replace('DummyProviderImplementation', $providerConfig['implementation'], $stub);
+        }
+        
+        return $this;
+    }
+
+    /**
+     * Replace the instructions implementation in the stub.
+     */
+    protected function replaceInstructions(&$stub): static
+    {
+        $instructions = $this->option('instructions');
+        
+        if (!$instructions) {
+            $stub = str_replace(
+                'DummyInstructions',
+                '// TODO: Define your agent instructions here' . PHP_EOL . 
+                '        // Example: return \'You are a helpful AI assistant.\';',
+                $stub
+            );
+        } else {
+            $stub = str_replace('DummyInstructions', "return '{$instructions}';", $stub);
+        }
+        
+        return $this;
+    }
+
+    /**
+     * Replace the tools configuration in the stub.
+     */
+    protected function replaceTools(&$stub): static
+    {
+        $tools = $this->option('tools');
+        
+        if (!$tools) {
+            $stub = str_replace('DummyToolsImports', '', $stub);
+            $stub = str_replace('DummyToolsConfiguration', '', $stub);
+        } else {
+            $toolsArray = array_map('trim', explode(',', $tools));
+            $toolsConfig = $this->generateToolsConfiguration($toolsArray);
+            
+            $stub = str_replace('DummyToolsImports', $toolsConfig['imports'], $stub);
+            $stub = str_replace('DummyToolsConfiguration', $toolsConfig['configuration'], $stub);
+        }
+        
+        return $this;
+    }
+
+    /**
+     * Get the provider configuration.
+     */
+    protected function getProviderConfig(string $provider): array
+    {
+        $providerMap = [
+            'openai' => [
+                'import' => 'use NeuronAI\Providers\OpenAIProvider;',
+                'implementation' => 'return OpenAIProvider::make();'
+            ],
+            'anthropic' => [
+                'import' => 'use NeuronAI\Providers\AnthropicProvider;',
+                'implementation' => 'return AnthropicProvider::make();'
+            ],
+            'gemini' => [
+                'import' => 'use NeuronAI\Providers\GeminiProvider;',
+                'implementation' => 'return GeminiProvider::make();'
+            ],
+            'ollama' => [
+                'import' => 'use NeuronAI\Providers\OllamaProvider;',
+                'implementation' => 'return OllamaProvider::make();'
+            ],
+        ];
+
+        if (!isset($providerMap[$provider])) {
+            $this->warn("Provider '{$provider}' not recognized. Using OpenAI as default.");
+            return $providerMap['openai'];
+        }
+
+        return $providerMap[$provider];
+    }
+
+    /**
+     * Generate tools configuration.
+     */
+    protected function generateToolsConfiguration(array $tools): array
+    {
+        $imports = [];
+        $implementations = [];
+
+        foreach ($tools as $tool) {
+            $toolClass = Str::studly($tool) . 'Tool';
+            $imports[] = "use NeuronAI\\Tools\\{$toolClass};";
+            $implementations[] = "            {$toolClass}::make(),";
+        }
+
+        $configuration = PHP_EOL . '    /**' . PHP_EOL .
+                        '     * Configure the tools for this agent.' . PHP_EOL .
+                        '     */' . PHP_EOL .
+                        '    public function tools(): array' . PHP_EOL .
+                        '    {' . PHP_EOL .
+                        '        return [' . PHP_EOL .
+                        implode(PHP_EOL, $implementations) . PHP_EOL .
+                        '        ];' . PHP_EOL .
+                        '    }';
+
+        return [
+            'imports' => implode(PHP_EOL, $imports),
+            'configuration' => $configuration
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     */
+    protected function getOptions(): array
+    {
+        return [
+            ['provider', null, InputOption::VALUE_OPTIONAL, 'The AI provider to use (openai, anthropic, gemini, ollama)'],
+            ['instructions', null, InputOption::VALUE_OPTIONAL, 'Custom instructions for the agent'],
+            ['tools', null, InputOption::VALUE_OPTIONAL, 'Comma-separated list of tools to include'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'Custom directory path relative to app namespace'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the agent already exists'],
+        ];
+    }
+
+    /**
+     * Get the desired class name from the input.
+     */
+    protected function getNameInput(): string
+    {
+        $name = trim($this->argument('name'));
+        
+        // Asegurar que termine en 'Agent'
+        if (!Str::endsWith($name, 'Agent')) {
+            $name .= 'Agent';
+        }
+        
+        return $name;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        // Mostrar información si no se proporcionan opciones
+        if (!$this->hasAnyOptions()) {
+            $this->info('Generating agent with empty implementations.');
+            $this->comment('Use --provider, --instructions, or --tools to customize the generated agent.');
+        }
+
+        return parent::handle();
+    }
+
+    /**
+     * Check if any customization options were provided.
+     */
+    protected function hasAnyOptions(): bool
+    {
+        return $this->option('provider') || 
+               $this->option('instructions') || 
+               $this->option('tools');
+    }
+} 

--- a/src/Console/README.md
+++ b/src/Console/README.md
@@ -1,0 +1,144 @@
+# NeuronAI Console Commands
+
+Este directorio contiene comandos de consola para el framework NeuronAI.
+
+## Comando make:agent
+
+El comando `make:agent` permite generar nuevas clases de agentes AI de forma rápida y sencilla.
+
+### Instalación
+
+Para usar este comando en tu aplicación Laravel, registra el `ConsoleServiceProvider` en tu `config/app.php`:
+
+```php
+'providers' => [
+    // ... otros providers
+    NeuronAI\NeuronServiceProvider::class,
+],
+```
+
+O si usas Laravel 11+, puedes registrarlo en tu `bootstrap/providers.php`:
+
+```php
+<?php
+
+return [
+    // ... otros providers
+    NeuronAI\NeuronServiceProvider::class,
+];
+```
+
+### Uso Básico
+
+```bash
+# Generar un agente básico
+php artisan make:agent ChatAgent
+
+# Generar un agente con proveedor específico
+php artisan make:agent ChatAgent --provider=openai
+
+# Generar un agente con instrucciones personalizadas
+php artisan make:agent ChatAgent --instructions="You are a helpful customer support agent"
+
+# Generar un agente con herramientas
+php artisan make:agent ChatAgent --tools="WebSearch,EmailSender"
+
+# Generar un agente completo
+php artisan make:agent CustomerSupportAgent --provider=anthropic --instructions="You are a customer support agent" --tools="WebSearch,DatabaseQuery"
+```
+
+### Opciones Disponibles
+
+- `--provider`: Especifica el proveedor AI (openai, anthropic, gemini, ollama)
+- `--instructions`: Define las instrucciones personalizadas para el agente
+- `--tools`: Lista de herramientas separadas por comas
+- `--path`: Directorio personalizado (por defecto: `App\Agents`)
+- `--force`: Sobrescribir archivos existentes
+
+### Proveedores Soportados
+
+- `openai` → `OpenAIProvider::make()`
+- `anthropic` → `AnthropicProvider::make()`
+- `gemini` → `GeminiProvider::make()`
+- `ollama` → `OllamaProvider::make()`
+
+### Personalización de Stubs
+
+Puedes personalizar las plantillas publicando los stubs:
+
+```bash
+php artisan vendor:publish --tag=neuron-ai-stubs
+```
+
+Los stubs se publicarán en `stubs/neuron-ai/` donde podrás modificarlos según tus necesidades.
+
+### Ejemplos de Salida
+
+#### Agente Básico (sin opciones)
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agents;
+
+use NeuronAI\Agent;
+use NeuronAI\Providers\AIProviderInterface;
+
+class ChatAgent extends Agent
+{
+    public function provider(): AIProviderInterface
+    {
+        // TODO: Configure your AI provider here
+        // Example: return OpenAIProvider::make();
+    }
+
+    public function instructions(): string
+    {
+        // TODO: Define your agent instructions here
+        // Example: return 'You are a helpful AI assistant.';
+    }
+}
+```
+
+#### Agente Completo (con todas las opciones)
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Agents;
+
+use NeuronAI\Agent;
+use NeuronAI\Providers\AIProviderInterface;
+use NeuronAI\Providers\OpenAIProvider;
+use NeuronAI\Tools\WebSearchTool;
+use NeuronAI\Tools\DatabaseQueryTool;
+
+class CustomerSupportAgent extends Agent
+{
+    public function provider(): AIProviderInterface
+    {
+        return OpenAIProvider::make();
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a customer support agent';
+    }
+
+    public function tools(): array
+    {
+        return [
+            WebSearchTool::make(),
+            DatabaseQueryTool::make(),
+        ];
+    }
+}
+```
+
+### Convenciones
+
+- Los nombres de agentes automáticamente tendrán el sufijo "Agent" si no lo incluyes
+- El directorio por defecto es `App\Agents`
+- Sin opciones especificadas, se generan implementaciones vacías con comentarios TODO

--- a/src/Console/stubs/agent.stub
+++ b/src/Console/stubs/agent.stub
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DummyNamespace;
+
+use NeuronAI\Agent;
+use NeuronAI\Providers\AIProviderInterface;
+DummyProviderImport
+DummyToolsImports
+
+class DummyClass extends Agent
+{
+    /**
+     * Configure the AI provider for this agent.
+     */
+    public function provider(): AIProviderInterface
+    {
+        DummyProviderImplementation
+    }
+
+    /**
+     * Define the agent's instructions.
+     */
+    public function instructions(): string
+    {
+        DummyInstructions
+    }DummyToolsConfiguration
+} 

--- a/src/NeuronServiceProvider.php
+++ b/src/NeuronServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI;
+
+use Illuminate\Support\ServiceProvider;
+use NeuronAI\Console\Commands\AgentMakeCommand;
+
+class NeuronServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->commands([
+            AgentMakeCommand::class,
+        ]);
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/Console/stubs' => base_path('stubs/neuron-ai'),
+            ], 'neuron-ai-stubs');
+        }
+    }
+}


### PR DESCRIPTION
Examples:
#Generar un agente básico
php artisan make:agent YoutubeAgent

# Generar un agente con proveedor específico
php artisan make:agent YoutubeAgent --provider=openai

# Generar un agente con instrucciones personalizadas
php artisan make:agent YoutubeAgent --instructions="You are a helpful customer support agent"

# Generar un agente con herramientas
php artisan make:agent YoutubeAgent --tools="WebSearch,EmailSender"

# Generar un agente completo
php artisan make:agent CustomerSupportAgent --provider=anthropic --instructions="You are a customer support agent" --tools="WebSearch,DatabaseQuery"