### PR TITLE
Keep given instructions for RAG

### DIFF
--- a/src/RAG/RAG.php
+++ b/src/RAG/RAG.php
@@ -100,7 +100,7 @@ class RAG extends Agent
      */
     public function withDocumentsContext(array $documents): AgentInterface
     {
-        $originalInstructions = $this->instructions();
+        $originalInstructions = $this->resolveInstructions();
 
         // Remove the old context to avoid infinite grow
         $newInstructions = $this->removeDelimitedContent($originalInstructions, '<EXTRA-CONTEXT>', '</EXTRA-CONTEXT>');


### PR DESCRIPTION
When using RAG, user-given instructions are lost.
This PR fixes the issue and keeps the given instructions.