### PR TITLE
Add Metadata to Message Class for Displaying Actual User Input

### DIFF
--- a/src/Chat/Messages/Message.php
+++ b/src/Chat/Messages/Message.php
@@ -77,6 +77,14 @@ class Message implements \JsonSerializable
         return $this;
     }
 
+    public function getMetadata(): array {
+        return $this->meta;
+    }
+
+    public function getMetadataByKey(string $key): string|array|null {
+        return $this->meta[$key] ?? null;
+    }
+
     public function addMetadata(string $key, string|array|null $value): Message
     {
         $this->meta[$key] = $value;


### PR DESCRIPTION
Currently, when working with chat histories, user requests are sometimes embedded within larger prompt templates. For example:

```
You are a helpful agent. Please respond to the user request
** User Request **
{{ $UserRequest }}

Please respond only with the answer, no other text is required
```

In these cases, retrieving the original user message for display or logging purposes requires parsing out the user's text from the overall prompt, which is error-prone and cumbersome. I also see other cases where it maybe useful to get/set metadata to messages.

This PR updates the `Message` class to support fetching metadata, it is a protected property. 
