### PR TITLE
Fix tool filtering logic in McpConnector::tools()

### DIFF
--- a/src/MCP/McpConnector.php
+++ b/src/MCP/McpConnector.php
@@ -66,7 +66,9 @@ class McpConnector
         // Filter by the only and exclude preferences.
         $tools = \array_filter(
             $this->client->listTools(),
-            fn (array $tool): bool => \in_array($tool['name'], $this->exclude) && ($this->only === [] || \in_array($tool['name'], $this->only)),
+            fn (array $tool): bool =>
+                !\in_array($tool['name'], $this->exclude) &&
+                ($this->only === [] || \in_array($tool['name'], $this->only)),
         );
 
         return \array_map(fn (array $tool): ToolInterface => $this->createTool($tool), $tools);


### PR DESCRIPTION
Corrected the filtering logic in McpConnector::tools() to properly exclude tools listed in $exclude and include only those in $only when specified.

Previously, the logic kept tools that were in the $exclude list, which is the opposite of the intended behavior. This caused methods like ->only(['getResourceReference']) to return an empty array, even when the tool existed.

Also improved readability of the filter function for easier debugging.

Tested manually with MCP server and verified tool selection is now working as expected.