### PR TITLE
Add tests and CI service for Qdrant vector store

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,12 @@ on:
 jobs:
     ci:
         runs-on: ${{ matrix.os }}
-#        services:
+        services:
+            qdrant:
+                image: qdrant/qdrant:latest
+                ports:
+                    - 6333:6333
+                    - 6334:6334
 #            postgres:
 #                image: postgres
 #                env:

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -30,13 +30,17 @@ class QdrantVectorStore implements VectorStoreInterface
         ]);
     }
 
-    public function initialize(int $size, string $distance): void
+    public function initialize(int $size, string $distance, bool $override = false): void
     {
         $response = $this->client->get('exists')->getBody()->getContents();
         $response = \json_decode($response, true);
 
         if ($response['result']['exists']) {
-            return;
+            if ($override) {
+                $this->destroy();
+            } else {
+                return;
+            }
         }
 
         $this->client->put('', [

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -15,15 +15,18 @@ class QdrantVectorStore implements VectorStoreInterface
 
     public function __construct(
         protected string $collectionUrl, // like http://localhost:6333/collections/neuron-ai/
-        protected string $key,
+        protected ?string $key = null,
         protected int $topK = 4,
     ) {
+        $headers = ['Content-Type' => 'application/json'];
+
+        if ($this->key) {
+            $headers['api-key'] = $this->key;
+        }
+
         $this->client = new Client([
             'base_uri' => \trim($this->collectionUrl, '/').'/',
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'api-key' => $this->key,
-            ]
+            'headers' => $headers,
         ]);
     }
 

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -40,9 +40,11 @@ class QdrantVectorStore implements VectorStoreInterface
         }
 
         $this->client->put('', [
-            'vectors' => [
-                'size' => $size,
-                'distance' => $distance,
+            RequestOptions::JSON => [
+                'vectors' => [
+                    'size' => $size,
+                    'distance' => $distance,
+                ],
             ],
         ]);
     }

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -30,6 +30,23 @@ class QdrantVectorStore implements VectorStoreInterface
         ]);
     }
 
+    public function initialize(int $size, string $distance): void
+    {
+        $response = $this->client->get('exists')->getBody()->getContents();
+        $response = \json_decode($response, true);
+
+        if ($response['result']['exists']) {
+            return;
+        }
+
+        $this->client->put('', [
+            'vectors' => [
+                'size' => $size,
+                'distance' => $distance,
+            ],
+        ]);
+    }
+
     public function addDocument(Document $document): void
     {
         $this->client->put('points', [

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -60,22 +60,7 @@ class QdrantVectorStore implements VectorStoreInterface
 
     public function addDocument(Document $document): void
     {
-        $this->client->put('points', [
-            RequestOptions::JSON => [
-                'points' => [
-                    [
-                        'id' => $document->getId(),
-                        'payload' => [
-                            'content' => $document->getContent(),
-                            'sourceType' => $document->getSourceType(),
-                            'sourceName' => $document->getSourceName(),
-                            'metadata' => $document->metadata,
-                        ],
-                        'vector' => $document->getEmbedding(),
-                    ]
-                ]
-            ]
-        ]);
+        $this->addDocuments([$document]);
     }
 
     /**

--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -47,6 +47,11 @@ class QdrantVectorStore implements VectorStoreInterface
         ]);
     }
 
+    public function destroy(): void
+    {
+        $this->client->delete('');
+    }
+
     public function addDocument(Document $document): void
     {
         $this->client->put('points', [

--- a/tests/VectorStore/QdrantVectorStoreTest.php
+++ b/tests/VectorStore/QdrantVectorStoreTest.php
@@ -13,16 +13,25 @@ class QdrantVectorStoreTest extends TestCase
 {
     use CheckOpenPort;
 
+    public const SERVICE_PORT = 6333;
+    public const COLLECTION_NAME = 'neuron-ai';
+
+    public const VECTOR_DIMENSION = 3;
+    public const DISTANCE_METRIC = 'Cosine';
+
+    public const SOURCE_TYPE = 'manual';
+    public const SOURCE_NAME = 'manual';
+
     protected QdrantVectorStore $store;
 
     public function setUp(): void
     {
-        if (!$this->isPortOpen('127.0.0.1', 6333)) {
-            $this->markTestSkipped('Port 6333 is not open. Skipping test.');
+        if (!$this->isPortOpen('127.0.0.1', self::SERVICE_PORT)) {
+            $this->markTestSkipped(sprintf("Port %d is not open. Skipping test.", self::SERVICE_PORT));
         }
 
-        $this->store = new QdrantVectorStore('http://127.0.0.1:6333/collections/neuron-ai', '');
-        $this->store->initialize(3, 'Cosine', true);
+        $this->store = new QdrantVectorStore(sprintf("http://127.0.0.1:%d/collections/%s", self::SERVICE_PORT, self::COLLECTION_NAME));
+        $this->store->initialize(self::VECTOR_DIMENSION, self::DISTANCE_METRIC, true);
     }
 
     public function tearDown(): void
@@ -67,15 +76,19 @@ class QdrantVectorStoreTest extends TestCase
     public function test_delete_documents(): void
     {
         $document = new Document('Hello!');
+        $document->sourceType = self::SOURCE_TYPE;
+        $document->sourceName = self::SOURCE_NAME;
         $document->embedding = [1, 2, 3];
         $document->id = 1;
 
         $document2 = new Document('Hello 2!');
+        $document2->sourceType = self::SOURCE_TYPE;
+        $document2->sourceName = self::SOURCE_NAME;
         $document2->embedding = [3, 4, 5];
         $document2->id = 2;
 
         $this->store->addDocuments([$document, $document2]);
-        $this->store->deleteBySource('manual', 'manual');
+        $this->store->deleteBySource(self::SOURCE_TYPE, self::SOURCE_NAME);
 
         $results = $this->store->similaritySearch([1, 2, 3]);
         $this->assertCount(0, $results);

--- a/tests/VectorStore/QdrantVectorStoreTest.php
+++ b/tests/VectorStore/QdrantVectorStoreTest.php
@@ -6,56 +6,78 @@ namespace NeuronAI\Tests\VectorStore;
 
 use NeuronAI\RAG\Document;
 use NeuronAI\RAG\VectorStore\QdrantVectorStore;
+use NeuronAI\Tests\Traits\CheckOpenPort;
 use PHPUnit\Framework\TestCase;
 
 class QdrantVectorStoreTest extends TestCase
 {
-    public function test_store_documents(): void
+    use CheckOpenPort;
+
+    protected QdrantVectorStore $store;
+
+    public function setUp(): void
+    {
+        if (!$this->isPortOpen('127.0.0.1', 6333)) {
+            $this->markTestSkipped('Port 6333 is not open. Skipping test.');
+        }
+
+        $this->store = new QdrantVectorStore('http://127.0.0.1:6333/collections/neuron-ai', '');
+        $this->store->initialize(3, 'Cosine', true);
+    }
+
+    public function tearDown(): void
+    {
+        $this->store->destroy();
+    }
+
+    public function test_add_document_and_search(): void
+    {
+        $document = new Document('Hello World!');
+        $document->addMetadata('customProperty', 'customValue');
+        $document->embedding = [1, 2, 3];
+        $document->id = 1;
+
+        $this->store->addDocument($document);
+
+        $results = $this->store->similaritySearch([1, 2, 3]);
+
+        $this->assertEquals($document->getContent(), $results[0]->getContent());
+        $this->assertEquals($document->metadata['customProperty'], $results[0]->metadata['customProperty']);
+    }
+
+    public function test_add_multiple_document_and_search(): void
     {
         $document = new Document('Hello!');
         $document->addMetadata('customProperty', 'customValue');
         $document->embedding = [1, 2, 3];
         $document->id = 1;
-        $document->sourceName = 'test';
-        $document->sourceType = 'string';
 
         $document2 = new Document('Hello 2!');
         $document2->embedding = [3, 4, 5];
         $document2->id = 2;
-        $document2->sourceName = 'test';
-        $document2->sourceType = 'string';
 
-        $store = new QdrantVectorStore('http://localhost:6333/collections/neuron-ai', '');
+        $this->store->addDocuments([$document, $document2]);
 
-        $store->initialize(3, 'Cosine');
-        $store->addDocuments([$document, $document2]);
+        $results = $this->store->similaritySearch([1, 2, 3]);
 
-        $results = $store->similaritySearch([1, 2, 3]);
-
-        $this->assertCount(1, $results);
-        $this->assertEquals($document->id, $results[0]->getId());
-        $this->assertEquals($document->content, $results[0]->getContent());
-        $this->assertEquals($document->embedding, $results[0]->getEmbedding());
-        $this->assertEquals($document->sourceType, $results[0]->getSourceType());
-        $this->assertEquals($document->sourceName, $results[0]->getSourceName());
-        $this->assertEquals($document->metadata, $results[0]->metadata);
+        $this->assertEquals($document->getContent(), $results[0]->getContent());
+        $this->assertEquals($document->metadata['customProperty'], $results[0]->metadata['customProperty']);
     }
 
     public function test_delete_documents(): void
     {
         $document = new Document('Hello!');
         $document->embedding = [1, 2, 3];
+        $document->id = 1;
 
         $document2 = new Document('Hello 2!');
         $document2->embedding = [3, 4, 5];
+        $document2->id = 2;
 
-        $store = new QdrantVectorStore('http://localhost:6333/collections/neuron-ai', '');
+        $this->store->addDocuments([$document, $document2]);
+        $this->store->deleteBySource('manual', 'manual');
 
-        $store->initialize(3, 'Cosine');
-        $store->addDocuments([$document, $document2]);
-        $store->deleteBySource('manual', 'manual');
-
-        $results = $store->similaritySearch([1, 2, 3]);
+        $results = $this->store->similaritySearch([1, 2, 3]);
         $this->assertCount(0, $results);
     }
 }

--- a/tests/VectorStore/QdrantVectorStoreTest.php
+++ b/tests/VectorStore/QdrantVectorStoreTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\VectorStore;
+
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\VectorStore\QdrantVectorStore;
+use PHPUnit\Framework\TestCase;
+
+class QdrantVectorStoreTest extends TestCase
+{
+    public function test_store_documents(): void
+    {
+        $document = new Document('Hello!');
+        $document->addMetadata('customProperty', 'customValue');
+        $document->embedding = [1, 2, 3];
+        $document->id = 1;
+        $document->sourceName = 'test';
+        $document->sourceType = 'string';
+
+        $document2 = new Document('Hello 2!');
+        $document2->embedding = [3, 4, 5];
+        $document2->id = 2;
+        $document2->sourceName = 'test';
+        $document2->sourceType = 'string';
+
+        $store = new QdrantVectorStore('http://localhost:6333/collections/neuron-ai', '');
+
+        $store->initialize(3, 'Cosine');
+        $store->addDocuments([$document, $document2]);
+
+        $results = $store->similaritySearch([1, 2, 3]);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($document->id, $results[0]->getId());
+        $this->assertEquals($document->content, $results[0]->getContent());
+        $this->assertEquals($document->embedding, $results[0]->getEmbedding());
+        $this->assertEquals($document->sourceType, $results[0]->getSourceType());
+        $this->assertEquals($document->sourceName, $results[0]->getSourceName());
+        $this->assertEquals($document->metadata, $results[0]->metadata);
+    }
+
+    public function test_delete_documents(): void
+    {
+        $document = new Document('Hello!');
+        $document->embedding = [1, 2, 3];
+
+        $document2 = new Document('Hello 2!');
+        $document2->embedding = [3, 4, 5];
+
+        $store = new QdrantVectorStore('http://localhost:6333/collections/neuron-ai', '');
+
+        $store->initialize(3, 'Cosine');
+        $store->addDocuments([$document, $document2]);
+        $store->deleteBySource('manual', 'manual');
+
+        $results = $store->similaritySearch([1, 2, 3]);
+        $this->assertCount(0, $results);
+    }
+}


### PR DESCRIPTION
This pull request adds testing support for the Qdrant vector database by updating the workflow configuration to include Qdrant as a service, and adding tests for the store class. 

### Changes the Implementation Qdrant Vector Database:
* [`src/RAG/VectorStore/QdrantVectorStore.php`](diffhunk://#diff-19ef67febe7852eb69d1a6b9960eefd3e27d43c79ef11826d19b9d570d1de152L18-R46): Updated the `QdrantVectorStore` class to support optional API keys and dynamic initialization of collections. Added a new `initialize` method to handle collection creation if it does not exist.

### Tests for Qdrant Integration:
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-R17): Added Qdrant as a service in the CI workflow configuration, exposing ports `6333` and `6334` for communication.
* [`tests/VectorStore/QdrantVectorStoreTest.php`](diffhunk://#diff-e2296bbc78dce6076fdc852349edb786581b3ae22bd98a1460734dcaf6d76f28R1-R61): Added tests for the `QdrantVectorStore` class, including tests for storing, retrieving, and deleting documents. These tests ensure the functionality of similarity search and metadata handling.