### PR TITLE
Fix: SQLSTATE[HY093] in PGSQLSchemaTool

### DIFF
--- a/src/Tools/Toolkits/PGSQL/PGSQLSchemaTool.php
+++ b/src/Tools/Toolkits/PGSQL/PGSQLSchemaTool.php
@@ -201,7 +201,6 @@ and performance optimization. If you already know the database structure, you ca
     private function getRelationships(): array
     {
         $whereClause = "WHERE tc.table_schema = current_schema()";
-        $paramIndex = 1;
         $params = [];
 
         if ($this->tables !== null && $this->tables !== []) {
@@ -210,12 +209,13 @@ and performance optimization. If you already know the database structure, you ca
                 $placeholders[] = '?';
                 $params[] = $table;
             }
-            $additionalPlaceholders = [];
-            foreach ($this->tables as $table) {
-                $additionalPlaceholders[] = '$' . $paramIndex++;
-                $params[] = $table;
-            }
-            $whereClause .= " AND (tc.table_name = ANY(ARRAY[" . \implode(',', $placeholders) . "]) OR ccu.table_name = ANY(ARRAY[" . \implode(',', $additionalPlaceholders) . "]))";
+
+            $params = [
+                ...$params,
+                ...$params,
+            ];
+
+            $whereClause .= " AND (tc.table_name = ANY(ARRAY[" . \implode(',', $placeholders) . "]) OR ccu.table_name = ANY(ARRAY[" . \implode(',', $placeholders) . "]))";
         }
 
         $stmt = $this->pdo->prepare("


### PR DESCRIPTION
PR fixing the following error:

```
SQLSTATE[HY093]: Invalid parameter number: parameter was not defined
```

The error occurred when using the `PGSQLSchemaTool` tool with the defined argument `$tables`:

```php
$tool = new PGSQLSchemaTool(
    pdo: $pdo,
    tables: ['my_table'],
);

$result = $tool();
```

```
PDOException #HY093

SQLSTATE[HY093]: Invalid parameter number: parameter was not defined

File: .../neuron-ai/src/Tools/Toolkits/PGSQL/PGSQLSchemaTool.php:245
```