### PR TITLE
Fix Qdrant vector store id type #262

### DIFF
--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use NeuronAI\RAG\Document;
-use Ramsey\Uuid\Uuid;
 
 class QdrantVectorStore implements VectorStoreInterface
 {
@@ -61,7 +60,6 @@ class QdrantVectorStore implements VectorStoreInterface
      */
     public function addDocument(Document $document): VectorStoreInterface
     {
-        $document->id = Uuid::uuid4()->toString(); 
         return $this->addDocuments([$document]);
     }
 


### PR DESCRIPTION
• Removed previous dependency on ramsey/uuid
• Added optional parameter for document ID type in the Document object constructor
• Added private method for generating UUID v4 internally within the Document class