### PR TITLE
Add Provider Support for liteLLM

### DIFF
--- a/src/Providers/LiteLLM/LiteLLM.php
+++ b/src/Providers/LiteLLM/LiteLLM.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Providers\LiteLLM;
+
+use NeuronAI\Providers\HttpClientOptions;
+use NeuronAI\Providers\OpenAI\OpenAI;
+
+class LiteLLM extends OpenAI
+{
+    public function __construct(
+        protected string $baseUri,
+        protected string $key,
+        protected string $model,
+        protected array $parameters = [],
+        protected bool $strict_response = false,
+        protected ?HttpClientOptions $httpOptions = null,
+    ) {
+        parent::__construct($key, $model, $parameters, $strict_response, $httpOptions);
+    }
+}


### PR DESCRIPTION
Add https://www.litellm.ai/ AI Proxy support. liteLLM is API compatible to OpenAI, but needs a different API url

Usage:
```php
new LiteLLM(
  'https://your-littellm.instance.com',
  key: 'sk-...',
  model: 'gpt-4.1',
);
```