### PR TITLE
fix: cast document ID to string in addDocuments method

### DIFF
--- a/src/RAG/VectorStore/PineconeVectorStore.php
+++ b/src/RAG/VectorStore/PineconeVectorStore.php
@@ -48,7 +48,7 @@ class PineconeVectorStore implements VectorStoreInterface
             RequestOptions::JSON => [
                 'namespace' => $this->namespace,
                 'vectors' => \array_map(fn (Document $document): array => [
-                    'id' => $document->getId(),
+                    'id' => (string) $document->getId(),
                     'values' => $document->getEmbedding(),
                     'metadata' => [
                         'content' => $document->getContent(),


### PR DESCRIPTION
There is an error of the vector ID not being a string when using the Pinecone vector upsert.