### PR TITLE
fix: correct filter key in similarity search request

### DIFF
--- a/src/RAG/VectorStore/PineconeVectorStore.php
+++ b/src/RAG/VectorStore/PineconeVectorStore.php
@@ -87,7 +87,7 @@ class PineconeVectorStore implements VectorStoreInterface
                 'includeValues' => true,
                 'vector' => $embedding,
                 'topK' => $this->topK,
-                'filters' => $this->filters, // Hybrid search
+                'filter' => $this->filters, // Hybrid search
             ]
         ])->getBody()->getContents();
 


### PR DESCRIPTION
This fixes filtering vectors when using the Pinecone Vector Store. As per the API docs the request body is 'filter'.

https://docs.pinecone.io/reference/api/2025-04/data-plane/query#body-filter