### PR TITLE
Fix Gemini Embeddings config

### DIFF
--- a/src/RAG/Embeddings/GeminiEmbeddingsProvider.php
+++ b/src/RAG/Embeddings/GeminiEmbeddingsProvider.php
@@ -34,7 +34,7 @@ class GeminiEmbeddingsProvider extends AbstractEmbeddingsProvider
                 'content' => [
                     'parts' => [['text' => $text]]
                 ],
-                ...($this->config !== [] ? ['embedding_config' => $this->config] : []),
+                ...$this->config,
             ]
         ])->getBody()->getContents();
 


### PR DESCRIPTION
According to the [docs](https://ai.google.dev/api/embeddings#request-body) the `embedding_config` object no longer exists.
