### PR TITLE
Fix: Handle MCP tools without input parameters

### DIFF
--- a/src/MCP/McpConnector.php
+++ b/src/MCP/McpConnector.php
@@ -112,18 +112,22 @@ class McpConnector
             throw new McpException("Tool response format not supported: {$response['type']}");
         });
 
-        foreach ($item['inputSchema']['properties'] as $name => $prop) {
-            $required = \in_array($name, $item['inputSchema']['required'] ?? []);
+        // Only process properties if they exist in the input schema
+        // Some MCP tools don't require any input parameters
+        if (isset($item['inputSchema']['properties']) && is_array($item['inputSchema']['properties'])) {
+            foreach ($item['inputSchema']['properties'] as $name => $prop) {
+                $required = \in_array($name, $item['inputSchema']['required'] ?? []);
 
-            $type = PropertyType::fromSchema($prop['type'] ?? PropertyType::STRING->value);
+                $type = PropertyType::fromSchema($prop['type'] ?? PropertyType::STRING->value);
 
-            $property = match ($type) {
-                PropertyType::ARRAY => $this->createArrayProperty($name, $required, $prop),
-                PropertyType::OBJECT => $this->createObjectProperty($name, $required, $prop),
-                default => $this->createToolProperty($name, $type, $required, $prop),
-            };
+                $property = match ($type) {
+                    PropertyType::ARRAY => $this->createArrayProperty($name, $required, $prop),
+                    PropertyType::OBJECT => $this->createObjectProperty($name, $required, $prop),
+                    default => $this->createToolProperty($name, $type, $required, $prop),
+                };
 
-            $tool->addProperty($property);
+                $tool->addProperty($property);
+            }
         }
 
         return $tool;


### PR DESCRIPTION
## Description
This PR fixes a bug where McpConnector throws an error when working with MCP tools that don't require input parameters.

## Problem
The `createTool()` method assumes all MCP tools have an `inputSchema.properties` field, but according to the MCP specification, tools without input parameters don't need this field. This causes an "Undefined array key 'properties'" error.

## Solution
Added a check for the existence of `inputSchema.properties` before attempting to iterate over it.

## Changes
- Wrapped the properties iteration (lines 115-131) in an `isset()` check
- Added explanatory comment about why this check is necessary

## Testing
- Tested with Laravel Boost MCP server - now works correctly
- Tested with existing MCP tools that have parameters - still works as before
- Both tools with and without input parameters are handled properly

## Affected Systems
This bug prevented integration with:
- Laravel Boost MCP server
- Any other MCP servers that correctly follow the spec

## Example Error (Before Fix)
```
Undefined array key "properties" at vendor/inspector-apm/neuron-ai/src/MCP/McpConnector.php:119
```

This is a non-breaking change that improves compatibility with the MCP specification.