### PR TITLE
Refactor image attachment mapping type in OpenAI responses API

### DIFF
--- a/src/Providers/OpenAI/Responses/MessageMapperResponses.php
+++ b/src/Providers/OpenAI/Responses/MessageMapperResponses.php
@@ -90,16 +90,12 @@ class MessageMapperResponses implements MessageMapperInterface
     {
         return match($attachment->contentType) {
             AttachmentContentType::URL => [
-                'type' => 'image_url',
-                'image_url' => [
-                    'url' => $attachment->content,
-                ],
+                'type' => 'input_image',
+                'image_url' => $attachment->content,
             ],
             AttachmentContentType::BASE64 => [
-                'type' => 'image_url',
-                'image_url' => [
-                    'url' => 'data:'.$attachment->mediaType.';base64,'.$attachment->content,
-                ],
+                'type' => 'input_image',
+                'image_url' => 'data:'.$attachment->mediaType.';base64,'.$attachment->content,
             ]
         };
     }


### PR DESCRIPTION
The responses API uses a different structure that what is set on the mapper for image inputs

<img width="1492" height="748" alt="image" src="https://github.com/user-attachments/assets/3d0ea110-056d-437f-9df9-d2169ad71f73" />
