### PR TITLE
Fix: Empty function arguments should be {}

### DIFF
--- a/src/Providers/OpenAI/Responses/MessageMapperResponses.php
+++ b/src/Providers/OpenAI/Responses/MessageMapperResponses.php
@@ -106,10 +106,11 @@ class MessageMapperResponses implements MessageMapperInterface
     protected function mapToolCall(ToolCallMessage $message): void
     {
         foreach ($message->getTools() as $tool) {
+            $inputs = $tool->getInputs();
             $this->mapping[] = [
                 'type' => 'function_call',
                 'name' => $tool->getName(),
-                'arguments' => \json_encode($tool->getInputs()),
+                'arguments' => \json_encode($inputs !== [] ? $inputs : new \stdClass()),
                 'call_id' => $tool->getCallId(),
             ];
         }


### PR DESCRIPTION
## Problem
OpenAI Responses API was returning `400 Bad Request` errors when calling functions with no parameters. The issue occurred because empty function arguments were being serialized as `"[]"` (empty array) instead of `"{}"` (empty object).

## Root Cause
In `MessageMapperResponses.php`, the `mapToolCall` method was directly encoding `$tool->getInputs()` which returns an empty array `[]` for functions without parameters:

```php
'arguments' => \json_encode($tool->getInputs()),
```

When `json_encode([])` is called, it produces `"[]"` as a string, but the OpenAI Responses API validates function arguments against the function's parameter schema, which expects an object (even if empty).

## Solution
Following the same pattern used in `Gemini\MessageMapper.php`, convert empty arrays to `stdClass` before JSON encoding:

```php
$inputs = $tool->getInputs();
'arguments' => \json_encode($inputs !== [] ? $inputs : new \stdClass()),
```

This ensures:
- Functions **with parameters** → `arguments: "{\"param\":\"value\"}"`  
- Functions **without parameters** → `arguments: "{}"`

## Testing
- [x] Functions with parameters work correctly
- [x] Functions without parameters (e.g., `health_check`) now return `"{}"` and pass API validation
- [x] No linter errors introduced

## References
- [OpenAI Responses API Documentation](https://platform.openai.com/docs/api-reference/responses)