### PR TITLE
refactor MessageMapperResponses to improve user message detection logic

### DIFF
--- a/src/Providers/OpenAI/Responses/MessageMapperResponses.php
+++ b/src/Providers/OpenAI/Responses/MessageMapperResponses.php
@@ -76,7 +76,7 @@ class MessageMapperResponses implements MessageMapperInterface
 
     protected function isUserMessage(Message $message): bool
     {
-        return $message instanceof UserMessage || $message->getRole() === MessageRole::USER;
+        return $message instanceof UserMessage || $message->getRole() === MessageRole::USER->value;
     }
 
     public function mapDocumentAttachment(Attachment $attachment): array


### PR DESCRIPTION
## Scenario:
from ([docs](https://docs.neuron-ai.dev/the-basics/chat-history-and-memory#how-to-feed-a-previous-conversation)):

```php
use NeuronAI\Chat\Enums\MessageRole;
use NeuronAI\Chat\Messages\Message;

$response = MyAgent::make()
    ->chat([
        new Message(MessageRole::USER, "Hi, my company is called Inspector.dev"),
        new Message(MessageRole::ASSISTANT, "Hi, how can I assist you today?"),
        new Message(MessageRole::USER, "What's the name of the company I work for?"),
    ]);
    
echo $response->getContent();

```

MyAgent is provided by OpenAi like:

```php
protected function provider(): AIProviderInterface
{
    return new OpenAIResponses(
        key: 'XXXXXXXXXXXXXXXX',
        model: 'gpt-4.1-nano',
        parameters: [
            'temperature' => 0.1,
        ],
        strict_response: false,
        httpOptions: new HttpClientOptions(timeout: 60),
    );
}
```

## Result

When executing such code, i get 
```
Client error: `POST https://api.openai.com/v1/responses` resulted in a `400 Bad Request` response:
{
  "error": {
    "message": "Invalid value: 'output_text'. Supported values are: 'input_text', 'input_image', and 'inp (truncated...)

```

## Change:

Since the payload needs at least one input_* and the set of the type was made only by:
```php
'type' => $message instanceof UserMessage ? 'input_text' : 'output_text',
```

I've added also a check on the user role:
```php
protected function isUserMessage(Message $message): bool
{
    return $message instanceof UserMessage || $message->getRole() === MessageRole::USER->value;
}
```

This behavior is not available if you pass a `UserMessage` instead of a generic `Message`
