### PR TITLE
Fix StaticConstructor::make() to support named parameters

### DIFF
--- a/src/StaticConstructor.php
+++ b/src/StaticConstructor.php
@@ -12,39 +12,75 @@ trait StaticConstructor
     public static function make(...$arguments): static
     {
         // Handle named parameters by converting them to positional arguments
-        if (count($arguments) === 1 && is_array($arguments[0]) && array_keys($arguments[0]) !== range(0, count($arguments[0]) - 1)) {
-            // This is an associative array (named parameters)
+
+        // Check if arguments represent named parameters (associative array)
+        if (!empty($arguments) && isset($arguments[0]) && is_array($arguments[0])) {
+            // Case 1: Single array argument (Tool::make(['name' => 'test', 'desc' => 'desc']))
             $namedArgs = $arguments[0];
 
-            // Use reflection to map named parameters to constructor positions
-            $reflection = new \ReflectionClass(static::class);
-            $constructor = $reflection->getConstructor();
-
-            if ($constructor) {
-                $params = $constructor->getParameters();
-                $positionalArgs = [];
-
-                foreach ($params as $param) {
-                    $paramName = $param->getName();
-                    if (array_key_exists($paramName, $namedArgs)) {
-                        $positionalArgs[] = $namedArgs[$paramName];
-                    } else {
-                        // Use default value if available
-                        if ($param->isDefaultValueAvailable()) {
-                            $positionalArgs[] = $param->getDefaultValue();
-                        } else {
-                            // Parameter is required but not provided
-                            throw new \ArgumentCountError("Missing required parameter: {$paramName}");
-                        }
-                    }
-                }
-
-                /** @phpstan-ignore new.static */
-                return new static(...$positionalArgs);
+            if (array_keys($namedArgs) !== range(0, count($namedArgs) - 1)) {
+                // This is an associative array (named parameters)
+                return self::createFromNamedArgs($namedArgs);
             }
+
+            // If it's a sequential array, treat as positional arguments
+            /** @phpstan-ignore new.static */
+            return new static(...$namedArgs);
         }
 
+        // Case 2: Named parameters passed directly (Tool::make(name: 'test', desc: 'desc'))
+        // In this case, $arguments itself is an associative array
+        if (self::isAssociativeArray($arguments)) {
+            return self::createFromNamedArgs($arguments);
+        }
+
+        // Case 3: Regular positional parameters
         /** @phpstan-ignore new.static */
         return new static(...$arguments);
+    }
+
+    /**
+     * Check if an array is associative (has string keys)
+     */
+    private static function isAssociativeArray(array $array): bool
+    {
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+
+    /**
+     * Create instance from named arguments using reflection
+     */
+    private static function createFromNamedArgs(array $namedArgs): static
+    {
+        // Use reflection to map named parameters to constructor positions
+        $reflection = new \ReflectionClass(static::class);
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor) {
+            $params = $constructor->getParameters();
+            $positionalArgs = [];
+
+            foreach ($params as $param) {
+                $paramName = $param->getName();
+                if (array_key_exists($paramName, $namedArgs)) {
+                    $positionalArgs[] = $namedArgs[$paramName];
+                } else {
+                    // Use default value if available
+                    if ($param->isDefaultValueAvailable()) {
+                        $positionalArgs[] = $param->getDefaultValue();
+                    } else {
+                        // Parameter is required but not provided
+                        throw new \ArgumentCountError("Missing required parameter: {$paramName}");
+                    }
+                }
+            }
+
+            /** @phpstan-ignore new.static */
+            return new static(...$positionalArgs);
+        }
+
+        // Fallback: try to pass named args as-is (will likely fail but better than nothing)
+        /** @phpstan-ignore new.static */
+        return new static(...$namedArgs);
     }
 }

--- a/tests/StaticConstructorTest.php
+++ b/tests/StaticConstructorTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests;
+
+use NeuronAI\StaticConstructor;
+use NeuronAI\Tools\Tool;
+use PHPUnit\Framework\TestCase;
+
+class StaticConstructorTest extends TestCase
+{
+    public function test_make_with_positional_parameters(): void
+    {
+        // Test that existing positional parameters still work
+        $tool = Tool::make('test_tool', 'Test description');
+
+        $this->assertEquals('test_tool', $tool->getName());
+        $this->assertEquals('Test description', $tool->getDescription());
+    }
+
+    public function test_make_with_associative_array(): void
+    {
+        // This is the main use case from MCP connector
+        $namedArgs = [
+            'name' => 'test_tool',
+            'description' => 'Test description'
+        ];
+
+        $tool = Tool::make($namedArgs);
+
+        $this->assertEquals('test_tool', $tool->getName());
+        $this->assertEquals('Test description', $tool->getDescription());
+    }
+
+    public function test_make_with_associative_array_partial(): void
+    {
+        // Test that associative array with optional values work
+        $namedArgs = [
+            'name' => 'test_tool'
+            // description is optional
+        ];
+
+        $tool = Tool::make($namedArgs);
+
+        $this->assertEquals('test_tool', $tool->getName());
+        $this->assertEquals(null, $tool->getDescription());
+    }
+
+    public function test_make_with_associative_array_reordered(): void
+    {
+        // Test that associative array parameters work in any order
+        $namedArgs = [
+            'description' => 'Test description',
+            'name' => 'test_tool'
+        ];
+
+        $tool = Tool::make($namedArgs);
+
+        $this->assertEquals('test_tool', $tool->getName());
+        $this->assertEquals('Test description', $tool->getDescription());
+    }
+
+    public function test_make_with_associative_array_missing_required(): void
+    {
+        // Test that missing required parameters throw an exception
+        $this->expectException(\ArgumentCountError::class);
+        $this->expectExceptionMessage('Missing required parameter: name');
+
+        $namedArgs = [
+            'description' => 'Test description'
+            // name is required but missing
+        ];
+
+        Tool::make($namedArgs);
+    }
+
+    public function test_make_with_positional_parameters_backward_compatibility(): void
+    {
+        // Test that the old way still works (backward compatibility)
+        $tool = Tool::make('test_tool', 'Test description', []);
+
+        $this->assertEquals('test_tool', $tool->getName());
+        $this->assertEquals('Test description', $tool->getDescription());
+    }
+
+    public function test_make_with_sequential_array(): void
+    {
+        // Test that sequential arrays are treated as positional arguments
+        $positionalArgs = ['test_tool', 'Test description'];
+
+        $tool = Tool::make($positionalArgs);
+
+        $this->assertEquals('test_tool', $tool->getName());
+        $this->assertEquals('Test description', $tool->getDescription());
+    }
+
+    public function test_make_with_empty_array(): void
+    {
+        // Test that empty array triggers missing required parameter error
+        $this->expectException(\ArgumentCountError::class);
+        $this->expectExceptionMessage('Missing required parameter: name');
+
+        Tool::make([]);
+    }
+
+    public function test_make_with_mcp_use_case(): void
+    {
+        // Test the exact use case from MCP connector that was failing
+        $mcpToolData = [
+            'name' => 'list_projects',
+            'description' => 'List all projects with details including task counts and progress'
+        ];
+
+        $tool = Tool::make($mcpToolData);
+
+        $this->assertEquals('list_projects', $tool->getName());
+        $this->assertEquals('List all projects with details including task counts and progress', $tool->getDescription());
+    }
+
+    public function test_make_with_direct_named_parameters(): void
+    {
+        // Test the actual failing case: direct named parameters in function call
+        // This is what was actually causing the "Unknown named parameter $name" error
+        $tool = Tool::make(
+            name: 'test_direct_named',
+            description: 'Test direct named parameters'
+        );
+
+        $this->assertEquals('test_direct_named', $tool->getName());
+        $this->assertEquals('Test direct named parameters', $tool->getDescription());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the StaticConstructor trait to properly support PHP 8+ named parameters, resolving "Unknown named parameter $name" errors when using MCP (Model Context Protocol) functionality.

## Problem

The `StaticConstructor::make()` method didn't handle named parameters correctly. When the MCP connector called:

```php
$tool = Tool::make(
    name: $item['name'],
    description: $item['description'] ?? null
)
```

It resulted in: `Unknown named parameter $name` at `vendor/neuron-core/neuron-ai/src/Tools/Tool.php:226`

## Root Cause

PHP named parameters with the `...$arguments` operator create an associative array directly, but the StaticConstructor trait was trying to pass named parameters as positional arguments to the constructor.

## Solution

Enhanced the `StaticConstructor::make()` method to:

1. **Detect named parameters** in both formats:
   - Direct: `Tool::make(name: 'test', desc: 'desc')`
   - Array: `Tool::make(['name' => 'test', 'desc' => 'desc'])`

2. **Use reflection** to map parameter names to constructor positions

3. **Handle default values** for optional parameters correctly

4. **Maintain backward compatibility** with existing positional parameters

## Changes

- **Enhanced** `src/StaticConstructor.php` with comprehensive named parameter support
- **Added** `tests/StaticConstructorTest.php` with 10 test cases covering all scenarios
- **Refactored** logic into helper methods for better maintainability

## Test Coverage

✅ Direct named parameters: `Tool::make(name: 'test', description: 'desc')`
✅ Associative arrays: `Tool::make(['name' => 'test', 'description' => 'desc'])`
✅ Partial parameters with defaults
✅ Reordered parameters
✅ Missing required parameters (proper error handling)
✅ Backward compatibility with positional parameters
✅ Sequential arrays as positional arguments
✅ Empty array handling
✅ MCP connector use case

## Impact

- **Fixes** MCP functionality that was broken
- **Enables** modern PHP 8+ named parameter usage
- **Maintains** full backward compatibility
- **Provides** clear error messages for missing parameters

Resolves #341