### PR TITLE
Fix - Ollama httpOptions headers

### DIFF
--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -40,6 +40,7 @@ class Ollama implements AIProviderInterface
     ) {
         $config = [
             'base_uri' => \trim($this->url, '/').'/',
+            'headers' => [],
         ];
 
         if ($this->httpOptions instanceof HttpClientOptions) {


### PR DESCRIPTION
When the httpOptions parameter is filled with headers in the Ollama provider, the following error is thrown:
array_merge(): Argument #1 must be of type array, null given