### PR TITLE
Add annotations to tools

### DIFF
--- a/src/MCP/McpConnector.php
+++ b/src/MCP/McpConnector.php
@@ -91,7 +91,8 @@ class McpConnector
     {
         $tool = Tool::make(
             name: $item['name'],
-            description: $item['description'] ?? null
+            description: $item['description'] ?? null,
+            annotations: $item['annotations'] ?? [],
         )->setCallable(function (...$arguments) use ($item) {
             $response = \call_user_func($this->client->callTool(...), $item['name'], $arguments);
 

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -11,7 +11,7 @@ use NeuronAI\StructuredOutput\Deserializer\Deserializer;
 use NeuronAI\StructuredOutput\Deserializer\DeserializerException;
 
 /**
- * @method static static make(?string $name = null, ?string $description = null, array $properties = [])
+ * @method static static make(?string $name = null, ?string $description = null, array $properties = [], array $annotations = [])
  */
 class Tool implements ToolInterface
 {
@@ -51,11 +51,13 @@ class Tool implements ToolInterface
      * Tool constructor.
      *
      * @param ToolPropertyInterface[] $properties
+     * @param array<string, mixed> $annotations
      */
     public function __construct(
         protected string $name,
         protected ?string $description = null,
-        array $properties = []
+        array $properties = [],
+        protected array $annotations = [],
     ) {
         if ($properties !== []) {
             $this->properties = $properties;
@@ -84,6 +86,14 @@ class Tool implements ToolInterface
     protected function properties(): array
     {
         return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAnnotations(): array
+    {
+        return $this->annotations;
     }
 
     /**

--- a/src/Tools/ToolInterface.php
+++ b/src/Tools/ToolInterface.php
@@ -27,6 +27,12 @@ interface ToolInterface extends \JsonSerializable
     public function getProperties(): array;
 
     /**
+     * Get the annotations present on the tool.
+     * @return array<string, mixed>
+     */
+    public function getAnnotations(): array;
+
+    /**
      * Names of the required properties.
      *
      * @return array<string>

--- a/tests/Tools/ToolTest.php
+++ b/tests/Tools/ToolTest.php
@@ -465,4 +465,16 @@ class ToolTest extends TestCase
         $this->assertEquals('test tool', $tool->getDescription());
         $this->assertEquals('test', $tool->getKey());
     }
+
+    public function test_annotations(): void
+    {
+        $tool = Tool::make('foo-bar', 'description', annotations: [
+            'readOnly' => true,
+            'idempotent' => false,
+        ]);
+        $this->assertEquals([
+            'readOnly' => true,
+            'idempotent' => false,
+        ], $tool->getAnnotations());
+    }
 }


### PR DESCRIPTION
MCP servers may define annotations on tools which may provide useful metadata, see https://modelcontextprotocol.io/legacy/concepts/tools#tool-annotations

This pull request adds annotations to the ToolInterface and Tool class such that developers can access annotations present on tools.


P.S. Nice work on this package! 🚀 