### PR TITLE
Fix: Typo in Tool Max Tries Variable Name

### DIFF
--- a/src/HandleTools.php
+++ b/src/HandleTools.php
@@ -33,7 +33,7 @@ trait HandleTools
     /**
      * Global max tries for all tools.
      */
-    protected int $tollMaxTries = 5;
+    protected int $toolMaxTries = 5;
 
     /**
      * @var array<string, int>
@@ -42,7 +42,7 @@ trait HandleTools
 
     public function toolMaxTries(int $tries): Agent
     {
-        $this->tollMaxTries = $tries;
+        $this->toolMaxTries = $tries;
         return $this;
     }
 
@@ -180,7 +180,7 @@ trait HandleTools
             $this->toolAttempts[$tool->getName()] = ($this->toolAttempts[$tool->getName()] ?? 0) + 1;
 
             // Single tool max tries have the highest priority on the global max tries.
-            $maxTries = $tool->getMaxTries() ?? $this->tollMaxTries;
+            $maxTries = $tool->getMaxTries() ?? $this->toolMaxTries;
             if ($this->toolAttempts[$tool->getName()] > $maxTries) {
                 throw new ToolMaxTriesException("Tool {$tool->getName()} has been attempted too many times: {$maxTries} attempts.");
             }

--- a/src/Tools/ParallelToolCalls.php
+++ b/src/Tools/ParallelToolCalls.php
@@ -48,7 +48,7 @@ trait ParallelToolCalls
             $this->toolAttempts[$tool->getName()] = ($this->toolAttempts[$tool->getName()] ?? 0) + 1;
 
             // Single tool max tries have the highest priority over the global max tries
-            $maxTries = $tool->getMaxTries() ?? $this->tollMaxTries;
+            $maxTries = $tool->getMaxTries() ?? $this->toolMaxTries;
             if ($this->toolAttempts[$tool->getName()] > $maxTries) {
                 throw new ToolMaxTriesException("Tool {$tool->getName()} has been attempted too many times: {$maxTries} attempts.");
             }


### PR DESCRIPTION
## Summary
- Fixed typo in tool max tries variable name: `tollMaxTries` → `toolMaxTries`

## Description
This PR corrects a typo in the variable name used for tracking the global maximum retry attempts for tools. The variable was incorrectly named `$tollMaxTries` instead of `$toolMaxTries`.

## Changes
- **src/HandleTools.php**:
  - Fixed property declaration from `$tollMaxTries` to `$toolMaxTries`
  - Updated property assignment in `toolMaxTries()` method
  - Updated property reference in `executeSingleTool()` method

- **src/Tools/ParallelToolCalls.php**:
  - Updated property reference in `executeTools()` method

## Testing
- All existing tests pass without modification
- The existing test `test_concurrent_tool_execution_respects_max_tries()` validates that the max tries functionality works correctly with both sequential and parallel tool execution

## Impact
This is a non-breaking change that fixes internal variable naming consistency. The public API (`toolMaxTries()` method) remains unchanged, and all functionality continues to work as expected.
