### PR TITLE
Fix RAG stub : change parameter from key to name

### DIFF
--- a/src/Console/Make/Stubs/rag.stub
+++ b/src/Console/Make/Stubs/rag.stub
@@ -31,7 +31,7 @@ class [classname] extends RAG
     {
         /*return new FileVectorStore(
             directory: __DIR__,
-            key: 'demo'
+            name: 'demo'
         );*/
     }
 }


### PR DESCRIPTION
Hi !

Small fix in the RAG stub : changed key to name to match the constructor.

Thanks for this package, it’s really cool !