### PR TITLE
fix enums on schemas

### DIFF
--- a/src/MCP/McpConnector.php
+++ b/src/MCP/McpConnector.php
@@ -139,7 +139,7 @@ class McpConnector
             type: $type,
             description: $prop['description'] ?? null,
             required: $required,
-            enum: $prop['items']['enum'] ?? []
+            enum: $prop['items']['enum'] ?? $prop['enum'] ?? []
         );
     }
 


### PR DESCRIPTION
This commit fixed problem with ignoring enums in schema parameters of simple types (string, integer, e.t.c)