### PR TITLE
Emit Events\Retrieved for rag-retrieved

### DIFF
--- a/src/RAG/Nodes/RetrieveDocumentsNode.php
+++ b/src/RAG/Nodes/RetrieveDocumentsNode.php
@@ -6,6 +6,7 @@ namespace NeuronAI\RAG\Nodes;
 
 use Inspector\Exceptions\InspectorException;
 use NeuronAI\Agent\AgentState;
+use NeuronAI\Observability\Events\Retrieved;
 use NeuronAI\Observability\Events\Retrieving;
 use NeuronAI\RAG\Events\DocumentsRetrievedEvent;
 use NeuronAI\RAG\Events\QueryPreProcessedEvent;
@@ -46,7 +47,7 @@ class RetrieveDocumentsNode extends Node
         }
         $retrievedDocs = \array_values($retrievedDocs);
 
-        $this->emit('rag-retrieved', new Retrieving($query));
+        $this->emit('rag-retrieved', new Retrieved($query, $documents));
 
         return new DocumentsRetrievedEvent($query, $retrievedDocs);
     }


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔧 Improvement/Enhancement (non-breaking change which improves existing functionality)
- [ ] 📖 Documentation update
- [ ] 🧹 Code cleanup/refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

### What does this PR do?
Fix an error in RetrieveDocumentsNode, where it would emit the wrong data for `rag-retrieved`

### Why is this change needed?
This would always break on RAG messages in v3


## Testing

- [x] I have tested this change locally
- [ ] I have added/updated unit tests where appropriate
- [ ] All existing tests pass
- [ ] I have tested this with different PHP versions (if applicable)

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces breaking changes (explain below)


## Documentation

- [x] No documentation changes needed
- [ ] I have updated relevant documentation
- [ ] Documentation will be updated in a separate PR
- [ ] New documentation needs to be created

## Checklist

- [x] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes
**Any additional information, concerns, or questions for reviewers**
