### PR TITLE
added file_id in attachment type and used in openai and anthropic

### DIFF
--- a/src/Chat/Enums/AttachmentContentType.php
+++ b/src/Chat/Enums/AttachmentContentType.php
@@ -8,4 +8,5 @@ enum AttachmentContentType: string
 {
     case URL = 'url';
     case BASE64 = 'base64';
+    case FILE_ID = 'file_id';
 }

--- a/src/Providers/Anthropic/MessageMapper.php
+++ b/src/Providers/Anthropic/MessageMapper.php
@@ -6,6 +6,7 @@ namespace NeuronAI\Providers\Anthropic;
 
 use NeuronAI\Chat\Attachments\Attachment;
 use NeuronAI\Chat\Enums\AttachmentContentType;
+use NeuronAI\Chat\Enums\AttachmentType;
 use NeuronAI\Chat\Enums\MessageRole;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\Message;
@@ -85,6 +86,13 @@ class MessageMapper implements MessageMapperInterface
                     'type' => 'base64',
                     'media_type' => $attachment->mediaType,
                     'data' => $attachment->content,
+                ],
+            ],
+            AttachmentContentType::FILE_ID => [
+                'type' => AttachmentType::DOCUMENT->value,
+                'source' => [
+                    'type' => 'file',
+                    'file_id' => $attachment->content,
                 ],
             ],
         };

--- a/src/Providers/OpenAI/MessageMapper.php
+++ b/src/Providers/OpenAI/MessageMapper.php
@@ -96,13 +96,21 @@ class MessageMapper implements MessageMapperInterface
 
     public function mapDocumentAttachment(Document $document): array
     {
-        return [
-            'type' => 'file',
-            'file' => [
-                'filename' => $document->filename ?? "attachment-".uniqid().".pdf",
-                'file_data' => "data:{$document->mediaType};base64,{$document->content}",
-            ]
-        ];
+        return match ($document->contentType) {
+            AttachmentContentType::BASE64 => [
+                'type' => 'file',
+                'file' => [
+                    'filename' => $document->filename ?? "attachment-".uniqid().".pdf",
+                    'file_data' => "data:{$document->mediaType};base64,{$document->content}",
+                ]
+            ],
+            AttachmentContentType::FILE_ID => [
+                'type' => 'file',
+                'file' => [
+                    'file_id' => $document->content,
+                ]
+            ],
+        };
     }
 
     protected function mapImageAttachment(Attachment $attachment): array
@@ -119,7 +127,13 @@ class MessageMapper implements MessageMapperInterface
                 'image_url' => [
                     'url' => 'data:'.$attachment->mediaType.';base64,'.$attachment->content,
                 ],
-            ]
+            ],
+            AttachmentContentType::FILE_ID => [
+                'type' => 'image_url',
+                'image_url' => [
+                    'url' => $attachment->content,
+                ],
+            ],
         };
     }
 

--- a/src/Providers/OpenAI/Responses/MessageMapperResponses.php
+++ b/src/Providers/OpenAI/Responses/MessageMapperResponses.php
@@ -97,7 +97,11 @@ class MessageMapperResponses implements MessageMapperInterface
                 'type' => 'input_file',
                 'filename' => $document->filename ?? "attachment-".uniqid().".pdf",
                 'file_data' => "data:{$document->mediaType};base64,{$document->content}",
-            ]
+            ],
+            AttachmentContentType::FILE_ID => [
+                'type' => 'input_file',
+                'file_id' => $document->content,
+            ],
         };
     }
 
@@ -111,6 +115,10 @@ class MessageMapperResponses implements MessageMapperInterface
             AttachmentContentType::BASE64 => [
                 'type' => 'input_image',
                 'image_url' => 'data:'.$attachment->mediaType.';base64,'.$attachment->content,
+            ],
+            AttachmentContentType::FILE_ID => [
+                'type' => 'input_image',
+                'image_id' => $attachment->content,
             ]
         };
     }


### PR DESCRIPTION
This PR aims to use "file_id" to refer a document in openai environment:

https://platform.openai.com/docs/guides/pdf-files?api-mode=responses#uploading-files
