### PR TITLE
Fix passing image by ID to model in OpenAiResponse

### DIFF
--- a/src/Providers/OpenAI/Responses/MessageMapper.php
+++ b/src/Providers/OpenAI/Responses/MessageMapper.php
@@ -118,7 +118,7 @@ class MessageMapper implements MessageMapperInterface
             ],
             SourceType::ID => [
                 'type' => 'input_image',
-                'image_id' => $block->content,
+                'file_id' => $block->content,
             ]
         };
     }


### PR DESCRIPTION
When passing image by ID, the correct parameter is file_id not image_id https://platform.openai.com/docs/guides/images-vision?format=file#giving-a-model-images-as-input