### PR TITLE
Add support for LocalAI reranker

### DIFF
--- a/src/RAG/PostProcessor/LocalAIRerankerPostProcessor.php
+++ b/src/RAG/PostProcessor/LocalAIRerankerPostProcessor.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NeuronAI\RAG\PostProcessor;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use NeuronAI\Chat\Messages\Message;
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\PostProcessor\PostProcessorInterface;
+
+class LocalAIRerankerPostProcessor implements PostProcessorInterface
+{
+    protected Client $client;
+
+    public function __construct(
+        protected string $key,
+        protected string $model = 'cross-encoder',
+        protected int    $topN = 3,
+        protected string $host = 'http://localhost:8080/v1/'
+    )
+    {
+    }
+
+    protected function getClient(): Client
+    {
+
+        return $this->client ?? $this->client = new Client([
+            'base_uri' => $this->host,
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer ' . $this->key,
+            ],
+        ]);
+    }
+
+    public function process(Message $question, array $documents): array
+    {
+        $response = $this->getClient()->post('rerank', [
+            RequestOptions::JSON => [
+                'model' => $this->model,
+                'query' => $question->getContent(),
+                'top_n' => $this->topN,
+                'documents' => \array_map(function (Document $document) {return $document->getContent();}, $documents),
+            ],
+        ])->getBody()->getContents();
+
+        $result = \json_decode($response, true);
+
+        return \array_map(function (array $item) use ($documents): Document {
+            $document = $documents[$item['index']];
+            $document->setScore($item['relevance_score']);
+            return $document;
+        }, $result['results']);
+    }
+
+    public function setClient(Client $client): PostProcessorInterface
+    {
+        $this->client = $client;
+        return $this;
+    }
+
+}

--- a/tests/PostProcessor/LocalAiRerankerPostProcessorTest.php
+++ b/tests/PostProcessor/LocalAiRerankerPostProcessorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\PostProcessor;
+
+use NeuronAI\Chat\Messages\UserMessage;
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\PostProcessor\LocalAIRerankerPostProcessor;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+
+use function json_encode;
+
+class LocalAiRerankerPostProcessorTest extends TestCase
+{
+    public function test_post_process_reranks_documents(): void
+    {
+        $sentRequests = [];
+        $history = Middleware::history($sentRequests);
+        $mockHandler = new MockHandler([
+            new Response(
+                status: 200,
+                body: json_encode([
+                    'results' => [
+                        ['index' => 1, 'relevance_score' => 0.9],
+                        ['index' => 0, 'relevance_score' => 0.2],
+                        ['index' => 2, 'relevance_score' => 0.1]
+                    ]
+                ])
+            )
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $postProcessor = (new LocalAIRerankerPostProcessor(''))->setClient($client);
+
+        $question = new UserMessage("What is the capital of Italy?");
+        $documents = [
+            new Document("Paris is the capital of France"),
+            new Document("Rome is the capital of Italy"),
+            new Document("Madrid is the capital of Spain"),
+            new Document("London is the capital of the United Kingdom")
+        ];
+
+        $result = $postProcessor->process($question, $documents);
+
+        $this->assertCount(3, $result, "LocalAI API returns 3 results by default");
+        $this->assertEquals("Rome is the capital of Italy", $result[0]->getContent(), "Rome should be the first result");
+        $this->assertEquals("Paris is the capital of France", $result[1]->getContent(), "Paris should be the second result");
+        $this->assertEquals("Madrid is the capital of Spain", $result[2]->getContent(), "Madrid should be the third result");
+    }
+
+    public function test_post_process_with_top_n_parameter(): void
+    {
+        $sentRequests = [];
+        $history = Middleware::history($sentRequests);
+        $mockHandler = new MockHandler([
+            new Response(
+                status: 200,
+                body: json_encode([
+                    'results' => [
+                        ['index' => 1, 'relevance_score' => 0.9],
+                        ['index' => 0, 'relevance_score' => 0.2]
+                    ]
+                ])
+            )
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push($history);
+
+        $client = new Client(['handler' => $stack]);
+
+        $postProcessor = (new LocalAIRerankerPostProcessor('', 'cross-encoder', 2))->setClient($client);
+
+        $question = new UserMessage("What is the capital of Italy?");
+        $documents = [
+            new Document("Paris is the capital of France"),
+            new Document("Rome is the capital of Italy"),
+            new Document("Madrid is the capital of Spain"),
+            new Document("London is the capital of the United Kingdom")
+        ];
+
+        $result = $postProcessor->process($question, $documents);
+
+        $this->assertCount(2, $result, "LocalAI API returns exactly top_n results");
+        $this->assertEquals("Rome is the capital of Italy", $result[0]->getContent(), "Rome should be the first result");
+        $this->assertEquals("Paris is the capital of France", $result[1]->getContent(), "Paris should be the second result");
+    }
+}


### PR DESCRIPTION
This PR adds a new `LocalAIRerankerPostProcessor` to support document reranking using a LocalAI rerank API.

####  What’s included
- New `LocalAIRerankerPostProcessor` implementation
- Supports `top_n` and specify reranker models
- PHPUnit tests
- No breaking changes

LocalAI provides an open-source, self-hosted alternative for LLM and reranking services.  
This addition allows users to integrate LocalAI into the RAG pipeline without relying on external APIs.

#### Backward compatibility
- No existing interfaces were modified
- No breaking changes introduced

#### Documentation
New documentation needs to be created

