### PR TITLE
Gemini VertexAI: Handle when usageMetadata does not contains token counts

### DIFF
--- a/src/Providers/Gemini/HandleStream.php
+++ b/src/Providers/Gemini/HandleStream.php
@@ -58,7 +58,8 @@ trait HandleStream
             }
 
             // Inform the agent about usage when stream
-            if (array_key_exists('usageMetadata', $line)) {
+            if (array_key_exists('usageMetadata', $line) && array_key_exists('promptTokenCount', $line['usageMetadata']) && 
+                array_key_exists('candidatesTokenCount', $line['usageMetadata'])) {
                 yield json_encode(['usage' => [
                     'input_tokens' => $line['usageMetadata']['promptTokenCount'],
                     'output_tokens' => $line['usageMetadata']['candidatesTokenCount'] ?? 0,


### PR DESCRIPTION
Hi!

During my tests, sometimes usageMetadata does not contains all you expect : 

Usual case : 
```
    [usageMetadata] => Array
        (
            [promptTokenCount] => 45
            [candidatesTokenCount] => 49
            [totalTokenCount] => 205
            [trafficType] => ON_DEMAND
            [promptTokensDetails] => Array
                (
                    [0] => Array
                        (
                            [modality] => TEXT
                            [tokenCount] => 45
                        )

                )

            [candidatesTokensDetails] => Array
                (
                    [0] => Array
                        (
                            [modality] => TEXT
                            [tokenCount] => 49
                        )

                )

            [thoughtsTokenCount] => 111
        )

```

Sometimes case : 
```
    [usageMetadata] => Array
        (
            [trafficType] => ON_DEMAND
        )
```

The PR fixes this. Thanks!