### PR TITLE
fix(gemini): handle missing 'parts' for all finish reasons

### DIFF
--- a/src/Providers/Gemini/HandleChat.php
+++ b/src/Providers/Gemini/HandleChat.php
@@ -23,8 +23,10 @@ trait HandleChat
 {
     /**
      * Finish reasons that indicate a blocked response (potentially retryable).
+     *
+     * @var array<string>
      */
-    private const BLOCKED_FINISH_REASONS = [
+    private static array $blockedFinishReasons = [
         'SAFETY',
         'BLOCKLIST',
         'OTHER',
@@ -73,7 +75,7 @@ trait HandleChat
                 // Handle missing 'parts' for all finish reasons
                 if (!isset($content['parts']) || empty($content['parts'])) {
                     // Blocked responses (SAFETY, BLOCKLIST, OTHER, RECITATION) - throw retryable exception
-                    if (in_array($finishReason, self::BLOCKED_FINISH_REASONS, true)) {
+                    if (in_array($finishReason, self::$blockedFinishReasons, true)) {
                         throw new ProviderException(
                             "Gemini response blocked (finishReason: {$finishReason}). " .
                             'This may be transient - retry recommended.'


### PR DESCRIPTION
## Summary

Fixes a crash ("Undefined array key 'parts'") when Gemini API returns responses without `parts` for finish reasons other than `MAX_TOKENS`.

### Problem

Gemini can return responses without `parts` for multiple finish reasons:
- `SAFETY` - Blocked by safety filters
- `BLOCKLIST` - Prohibited content detected
- `OTHER` - Catch-all (often image-related issues)
- `RECITATION` - Model repeated content excessively

The current code only handles `MAX_TOKENS`:

```php
if (!isset($content['parts']) && ... $finishReason === 'MAX_TOKENS') {
    return new Message(...);
}

$parts = $content['parts'];  // CRASHES if parts missing for other reasons!
```

### Solution

- Add check for missing/empty `candidates` with clear error message
- Handle `SAFETY`/`BLOCKLIST`/`OTHER`/`RECITATION` by throwing a `ProviderException` (allows callers to implement retry logic)
- Return empty message for `MAX_TOKENS`/`STOP` with missing parts
- Safely extract `content` with null coalescing

### Changes

| Before | After |
|--------|-------|
| Only handled `MAX_TOKENS` | Handles all finish reasons |
| Crashed on missing `parts` | Returns empty message or throws retryable exception |
| No candidates check | Checks for missing candidates |

## Test plan

- [x] Verify syntax with `php -l`
- [ ] Test with Gemini API when safety filter triggers (returns `SAFETY` finish reason)
- [ ] Test with images that trigger `OTHER` finish reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)