### PR TITLE
Refactor array_map to handle undefined tools safely

### DIFF
--- a/src/Tools/Toolkits/AbstractToolkit.php
+++ b/src/Tools/Toolkits/AbstractToolkit.php
@@ -71,7 +71,7 @@ abstract class AbstractToolkit implements ToolkitInterface
         }
 
         if ($this->with !== []) {
-            return array_map(fn (ToolInterface $tool): ToolInterface => $this->with[$tool::class]($tool) ?? $tool, $tools);
+            return array_map(fn (ToolInterface $tool): ToolInterface => isset($this->with[$tool::class]) ? ($this->with[$tool::class]($tool) ?? $tool) : $tool, $tools);
         }
 
         return $tools;


### PR DESCRIPTION
There was an issue when you used a Toolkit `with` method.

If you didn't define a `with` for all the Tools that the toolkit provided, it would trigger an exception of "undefined index"

This adds a check for whether it's "isset"; if so, it follows the previous null coalesce pattern, otherwise it returns the tool instance. 