### PR TITLE
Add bulk api call for OpenAi embeddings api.

### DIFF
--- a/src/RAG/Embeddings/OpenAIEmbeddingsProvider.php
+++ b/src/RAG/Embeddings/OpenAIEmbeddingsProvider.php
@@ -34,7 +34,7 @@ class OpenAIEmbeddingsProvider extends AbstractEmbeddingsProvider
         $inputs = [];
 
         foreach ($documents as $document) {
-            $text = $document->formattedContent ?? $document->content;
+            $text = $document->content;
             $inputs[] = $text;
         }
 


### PR DESCRIPTION
OpenAI supports generating embeddings from multiple documents or text inputs in a single request.
We can leverage this feature to avoid repeated API calls, which currently introduce an N+1 problem in our workflow.
https://platform.openai.com/docs/api-reference/embeddings/object
<img width="1395" height="768" alt="Screenshot 2026-02-09 at 1 17 05 PM" src="https://github.com/user-attachments/assets/081585e8-d136-456d-9e3c-0798660d5df3" />
