### PR TITLE
Fix Gemini 3 function-call detection in HandleChat

### DIFF
--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -18,6 +18,7 @@ use NeuronAI\Tools\ToolInterface;
 
 use function array_filter;
 use function array_map;
+use function array_values;
 
 class Gemini implements AIProviderInterface
 {
@@ -105,9 +106,11 @@ class Gemini implements AIProviderInterface
                 ->setCallId($item['functionCall']['name']);
         }, $message['parts']);
 
+        // array_values() reindexes so tools are always a 0-based sequential array,
+        // even when text/thought parts precede functionCall parts.
         $result = new ToolCallMessage(
             $message['content'] ?? null,
-            array_filter($tools)
+            array_values(array_filter($tools))
         );
 
         if ($signature !== null) {

--- a/src/Providers/Gemini/HandleChat.php
+++ b/src/Providers/Gemini/HandleChat.php
@@ -93,7 +93,18 @@ trait HandleChat
 
                 $parts = $content['parts'];
 
-                if (array_key_exists('functionCall', $parts[0]) && !empty($parts[0]['functionCall'])) {
+                // Scan ALL parts for functionCall, not just parts[0].
+                // Gemini 3 models may return text or thought parts before functionCall parts.
+                // See https://ai.google.dev/gemini-api/docs/thought-signatures
+                $hasFunctionCall = false;
+                foreach ($parts as $part) {
+                    if (array_key_exists('functionCall', $part) && !empty($part['functionCall'])) {
+                        $hasFunctionCall = true;
+                        break;
+                    }
+                }
+
+                if ($hasFunctionCall) {
                     $response = $this->createToolCallMessage($content);
                 } else {
                     $response = new AssistantMessage($parts[0]['text'] ?? '');


### PR DESCRIPTION
Closes #469.

## Problem

The non-streaming `HandleChat` trait only checks `parts[0]` for a `functionCall` key. Gemini 3 models (e.g. `gemini-3-pro-preview`, `gemini-3-flash-preview`) can return text or thought parts *before* the `functionCall` part — see [thought signatures](https://ai.google.dev/gemini-api/docs/thought-signatures). When this happens, the tool call is silently ignored and the response is treated as a plain `AssistantMessage`.

The streaming path (`HandleStream::hasToolCalls()`) already handles this correctly by iterating over all parts.

## Changes

**`HandleChat.php`** — Scan all parts for `functionCall` instead of only `parts[0]`, matching the approach used in `HandleStream::hasToolCalls()`.

**`Gemini.php`** — Wrap `array_filter($tools)` with `array_values()` in `createToolCallMessage()` so the tools array is always 0-indexed. Without this, when text/thought parts precede `functionCall` parts, `array_map` + `array_filter` produces non-sequential keys (e.g. `[1 => $tool]`).

**`GeminiTest.php`** — Five new test cases:
- Function call in first part (regression guard)
- Function call after a text part (the main fix)
- Multiple function calls after a text part
- No function call returns `AssistantMessage`
- `thoughtSignature` metadata is preserved

All existing tests continue to pass.