### PR TITLE
Add FactorialTool to CalculatorToolkit

### DIFF
--- a/src/Tools/Toolkits/Calculator/CalculatorToolkit.php
+++ b/src/Tools/Toolkits/Calculator/CalculatorToolkit.php
@@ -32,6 +32,7 @@ class CalculatorToolkit extends AbstractToolkit
             ModeTool::make(),
             StandardDeviationTool::make(),
             VarianceTool::make(),
+            FactorialTool::make(),
         ];
     }
 


### PR DESCRIPTION
 - Added missing FactorialTool to the CalculatorToolkit                                                   
  - The tool was already implemented but not registered in the toolkit's provide() method   