### PR TITLE
Only select role, content and meta for eloquent chat history

### DIFF
--- a/src/Chat/History/EloquentChatHistory.php
+++ b/src/Chat/History/EloquentChatHistory.php
@@ -34,6 +34,7 @@ class EloquentChatHistory extends AbstractChatHistory
 
         /** @var Collection<int, Model> $messages */
         $messages = $model->newQuery()
+            ->select(['role', 'content', 'meta'])
             ->where('thread_id', $this->threadId)
             ->orderBy('id')
             ->get();


### PR DESCRIPTION
Updated EloquentChatHistory to only select the fields that we need from the table.

My implementation of the messages table has additional fields which aren't needed and will eat up memory unneccesarily.

The Eloquent result is run through `$this->recordToArray(Model $record)` anyway to strip any irrelevant information.
