### PR TITLE
Refactor to create collection in a separate method

### DIFF
--- a/src/RAG/VectorStore/QdrantVectorStore.php
+++ b/src/RAG/VectorStore/QdrantVectorStore.php
@@ -173,7 +173,7 @@ class QdrantVectorStore implements VectorStoreInterface
         }, $response['result']['points']);
     }
 
-    private function createCollection(): void
+    protected function createCollection(): void
     {
         $this->httpClient->request(
             HttpRequest::put(


### PR DESCRIPTION
Allows you to override `createCollection` if you need to initialise indexes etc.