### PR TITLE
fix(openai): build embeddings url correctly

### DIFF
--- a/src/RAG/Embeddings/OpenAIEmbeddingsProvider.php
+++ b/src/RAG/Embeddings/OpenAIEmbeddingsProvider.php
@@ -18,7 +18,7 @@ class OpenAIEmbeddingsProvider extends AbstractEmbeddingsProvider
 {
     use HasHttpClient;
 
-    protected string $baseUri = 'https://api.openai.com/v1/embeddings';
+    protected string $baseUri = 'https://api.openai.com/v1';
 
     public function __construct(
         protected string $key,
@@ -40,7 +40,7 @@ class OpenAIEmbeddingsProvider extends AbstractEmbeddingsProvider
         $chunks = array_chunk($documents, 100);
 
         foreach ($chunks as $chunk) {
-            $response = $this->httpClient->request(HttpRequest::post('', [
+            $response = $this->httpClient->request(HttpRequest::post('embeddings', [
                 'model' => $this->model,
                 'input' => array_map(fn (Document $document): string => $document->getContent(), $chunk),
                 'encoding_format' => 'float',
@@ -57,7 +57,7 @@ class OpenAIEmbeddingsProvider extends AbstractEmbeddingsProvider
 
     public function embedText(string $text): array
     {
-        $response = $this->httpClient->request(HttpRequest::post('', [
+        $response = $this->httpClient->request(HttpRequest::post('embeddings', [
             'model' => $this->model,
             'input' => $text,
             'encoding_format' => 'float',


### PR DESCRIPTION
The underlying HTTP client implementation builds the base URL by appending `/` to the end. This is fine because Guzzle follows the RFC 3986 standard. However, prebuilding the full URL as the base URL will result in `https://api.openai.com/v1/embeddings/` (with trailing slash), which is invalid (OpenAI API call fails with this).

This PR moves the URL segment (`embeddings`) to each HTTP call to fix the problem.