### PR TITLE
Allow nullable location for Gemini Vertex, default to global

### DIFF
--- a/src/Providers/Gemini/GeminiVertex.php
+++ b/src/Providers/Gemini/GeminiVertex.php
@@ -17,14 +17,16 @@ class GeminiVertex extends Gemini
      */
     public function __construct(
         string $pathJsonCredentials,
-        string $location,
+        ?string $location,
         string $projectId,
         protected string $model,
         protected array $parameters = [],
         ?HttpClientInterface $httpClient = null,
     ) {
         // Set Vertex AI specific base URI
-        $this->baseUri = "https://{$location}-aiplatform.googleapis.com/v1/projects/{$projectId}/locations/{$location}/publishers/google/models";
+        $this->baseUri = $location !== null
+            ? "https://{$location}-aiplatform.googleapis.com/v1/projects/{$projectId}/locations/{$location}/publishers/google/models"
+            : "https://aiplatform.googleapis.com/v1/projects/{$projectId}/locations/global/publishers/google/models";
 
         $credentials = new ServiceAccountCredentials(
             'https://www.googleapis.com/auth/cloud-platform',


### PR DESCRIPTION
Currently the location parameter is required which limits Gemini Vertex usage to specific regions & models. 

There is a Global endpoint, see: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#use_the_global_endpoint 

This change allows null for the location so the base then uses the global endpoint. The provider will can be created like so:

```php
protected function provider(): AIProviderInterface
    {
        return new GeminiVertex(
            pathJsonCredentials: 'GOOGLE_FILE_CREDENTIALS_PATH',
            location: null,
            projectId: 'GOOGLE_PROJECT_ID',
            model: 'GEMINI_MODEL',
            parameters: [], // Add custom params (temperature, logprobs, etc)
        );
    }
``` 