### PR TITLE
Modify startEvent to resolve toolkit guidelines

### DIFF
--- a/src/Agent/Agent.php
+++ b/src/Agent/Agent.php
@@ -109,9 +109,12 @@ class Agent extends Workflow implements AgentInterface
      */
     protected function startEvent(): AgentStartEvent
     {
+        // The bootstrapTools method modifies the instructions, adding the toolkit guidelines, so we need to resolve them first
+        $tools = $this->bootstrapTools();
+
         return new AIInferenceEvent(
             $this->resolveInstructions(),
-            $this->bootstrapTools()
+            $tools
         );
     }
 


### PR DESCRIPTION
Resolve toolkit guidelines before creating AIInferenceEvent.

If we bootstrap the tools after we resolve the instructions, they're never going to receive the Toolkit Guidelines