### PR TITLE
Handle OpenAI API errors in processChatResult

### DIFF
--- a/src/Providers/OpenAI/Responses/HandleChat.php
+++ b/src/Providers/OpenAI/Responses/HandleChat.php
@@ -57,11 +57,11 @@ trait HandleChat
      */
     protected function processChatResult(array $result): AssistantMessage
     {
-        if (array_key_exists('error', $result)) {
+        if (isset($result['error']) {
             throw new ProviderException("OpenAI API Error: " . ($result['error']['message'] ?? json_encode($result['error'])));
         }
 
-        if (!array_key_exists('output', $result)) {
+        if (empty($result['output'])) {
             throw new ProviderException("OpenAI API Error: " . json_encode($result));
         }
 

--- a/src/Providers/OpenAI/Responses/HandleChat.php
+++ b/src/Providers/OpenAI/Responses/HandleChat.php
@@ -60,7 +60,7 @@ trait HandleChat
         }
 
         if (!array_key_exists('output', $result)) {
-            throw new ProviderException("OpenAI API Error: " . json_encode($result)));
+            throw new ProviderException("OpenAI API Error: " . json_encode($result));
         }
         
         $toolCalls = array_filter($result['output'], fn (array $item): bool => $item['type'] == 'function_call');

--- a/src/Providers/OpenAI/Responses/HandleChat.php
+++ b/src/Providers/OpenAI/Responses/HandleChat.php
@@ -61,8 +61,8 @@ trait HandleChat
             throw new ProviderException("OpenAI API Error: " . ($result['error']['message'] ?? json_encode($result['error'])));
         }
 
-        if (empty($result['output'])) {
-            throw new ProviderException("OpenAI API Error: " . json_encode($result));
+        if (!array_key_exists($result, 'output') || !is_array($result['output'])) {
+            throw new ProviderException("OpenAI API Error: No output - " . json_encode($result));
         }
 
         $toolCalls = array_filter($result['output'], fn (array $item): bool => $item['type'] == 'function_call');

--- a/src/Providers/OpenAI/Responses/HandleChat.php
+++ b/src/Providers/OpenAI/Responses/HandleChat.php
@@ -55,6 +55,14 @@ trait HandleChat
      */
     protected function processChatResult(array $result): AssistantMessage
     {
+        if (array_key_exists('error', $result)) {
+            throw new ProviderException("OpenAI API Error: " . ($result['error']['message'] ?? json_encode($result['error'])));
+        }
+
+        if (!array_key_exists('output', $result)) {
+            throw new ProviderException("OpenAI API Error: " . json_encode($result)));
+        }
+        
         $toolCalls = array_filter($result['output'], fn (array $item): bool => $item['type'] == 'function_call');
 
         $usage = new Usage($result['usage']['input_tokens'] ?? 0, $result['usage']['output_tokens'] ?? 0);

--- a/src/Providers/OpenAI/Responses/HandleChat.php
+++ b/src/Providers/OpenAI/Responses/HandleChat.php
@@ -12,6 +12,8 @@ use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\HttpClient\HttpRequest;
 
 use function array_filter;
+use function array_key_exists;
+use function json_encode;
 
 /**
  * Inspired by Andrew Monty - https://github.com/AndrewMonty
@@ -62,7 +64,7 @@ trait HandleChat
         if (!array_key_exists('output', $result)) {
             throw new ProviderException("OpenAI API Error: " . json_encode($result));
         }
-        
+
         $toolCalls = array_filter($result['output'], fn (array $item): bool => $item['type'] == 'function_call');
 
         $usage = new Usage($result['usage']['input_tokens'] ?? 0, $result['usage']['output_tokens'] ?? 0);


### PR DESCRIPTION
This pull request adds improved error handling to the `processChatResult` method in `src/Providers/OpenAI/Responses/HandleChat.php`. The main change is to ensure that errors returned from the OpenAI API are detected and reported clearly, making debugging and maintenance easier.

**Error handling improvements:**

* Added a check for an `'error'` key in the `$result` array, throwing a `ProviderException` with the error message if present.
* Added a check to ensure the `'output'` key exists in the `$result` array, throwing a `ProviderException` if it is missing.