### PR TITLE
fix: OpenAIImage stream TypeError + error / truncation handling

### DIFF
--- a/src/Providers/OpenAI/Image/OpenAIImage.php
+++ b/src/Providers/OpenAI/Image/OpenAIImage.php
@@ -22,8 +22,10 @@ use NeuronAI\Providers\AIProviderInterface;
 use NeuronAI\Providers\MessageMapperInterface;
 use NeuronAI\Providers\SSEParser;
 use NeuronAI\Providers\ToolMapperInterface;
+use NeuronAI\UniqueIdGenerator;
 
 use function end;
+use function is_string;
 
 class OpenAIImage implements AIProviderInterface
 {
@@ -142,7 +144,8 @@ class OpenAIImage implements AIProviderInterface
             )
         );
 
-        $content = '';
+        $messageId = UniqueIdGenerator::generateId('msg_');
+        $content = null;
         $usage = new Usage(0, 0);
 
         while (! $stream->eof()) {
@@ -150,17 +153,38 @@ class OpenAIImage implements AIProviderInterface
                 continue;
             }
 
-            // Image APIs stream entire partially generated images, not base64 chunks.
-            // The last content streamed is the final image.
-            if ($line['type'] === 'image_generation.partial_image') {
-                $content = $line['b64_json'];
-                yield new ImageChunk($line['partial_image_index'], $line['b64_json']);
+            $type = $line['type'] ?? null;
+
+            if ($type === 'error') {
+                throw new ProviderException(
+                    $line['error']['message'] ?? 'Image generation failed.'
+                );
             }
 
-            if (isset($line['usage'])) {
-                $usage->inputTokens = $line['usage']['input_tokens'] ?? 0;
-                $usage->outputTokens = $line['usage']['output_tokens'] ?? 0;
+            if ($type === 'image_generation.partial_image') {
+                $b64 = $line['b64_json'] ?? null;
+                if (!is_string($b64) || $b64 === '') {
+                    throw new ProviderException('Received a partial image event without b64_json payload.');
+                }
+                yield new ImageChunk($messageId, $b64);
             }
+
+            if ($type === 'image_generation.completed') {
+                $b64 = $line['b64_json'] ?? null;
+                if (!is_string($b64) || $b64 === '') {
+                    throw new ProviderException('Received a completed image event without b64_json payload.');
+                }
+                $content = $b64;
+
+                if (isset($line['usage'])) {
+                    $usage->inputTokens = $line['usage']['input_tokens'] ?? 0;
+                    $usage->outputTokens = $line['usage']['output_tokens'] ?? 0;
+                }
+            }
+        }
+
+        if ($content === null) {
+            throw new ProviderException('Image generation stream ended before a completed image was received.');
         }
 
         $result = new AssistantMessage(

--- a/tests/Providers/OpenAIImageTest.php
+++ b/tests/Providers/OpenAIImageTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeuronAI\Tests\Providers;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\Stream\Chunks\ImageChunk;
+use NeuronAI\Chat\Messages\UserMessage;
+use NeuronAI\Exceptions\ProviderException;
+use NeuronAI\HttpClient\GuzzleHttpClient;
+use NeuronAI\Providers\OpenAI\Image\OpenAIImage;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+
+class OpenAIImageTest extends TestCase
+{
+    public function test_chat_returns_image_message(): void
+    {
+        $body = '{"data":[{"b64_json":"FINAL_BASE64"}],"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30}}';
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $body),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            output_format: 'webp',
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        $message = $provider->chat(new UserMessage('A cat'));
+
+        $this->assertInstanceOf(AssistantMessage::class, $message);
+        $blocks = $message->getContentBlocks();
+        $this->assertInstanceOf(ImageContent::class, $blocks[0]);
+        $this->assertSame('FINAL_BASE64', $blocks[0]->content);
+    }
+
+    public function test_stream_yields_partials_and_uses_completed_event_for_final_image(): void
+    {
+        // Mock OpenAI Images streaming response:
+        //   - partial_image_index is an integer per the API spec.
+        //   - `completed` is the authoritative final image; no partial_image_index.
+        $streamBody = 'data: {"type":"image_generation.partial_image","partial_image_index":0,"b64_json":"PARTIAL_ONE"}'."\n\n";
+        $streamBody .= 'data: {"type":"image_generation.partial_image","partial_image_index":1,"b64_json":"PARTIAL_TWO"}'."\n\n";
+        $streamBody .= 'data: {"type":"image_generation.completed","b64_json":"FINAL","usage":{"input_tokens":15,"output_tokens":100,"total_tokens":115}}'."\n\n";
+        $streamBody .= "data: [DONE]\n\n";
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $streamBody),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            output_format: 'webp',
+            parameters: ['partial_images' => 2],
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        $generator = $provider->stream(new UserMessage('A cat'));
+
+        $chunks = [];
+        foreach ($generator as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $message = $generator->getReturn();
+
+        // Only partial events yield chunks; the completed event does not.
+        $this->assertCount(2, $chunks);
+        foreach ($chunks as $chunk) {
+            $this->assertInstanceOf(ImageChunk::class, $chunk);
+            // messageId is a non-empty string (StreamChunk contract).
+            $this->assertIsString($chunk->messageId);
+            $this->assertNotEmpty($chunk->messageId);
+        }
+
+        // All chunks in one stream share the same messageId.
+        $this->assertSame($chunks[0]->messageId, $chunks[1]->messageId);
+
+        // messageId uses the library-wide `msg_` prefix for consistency with
+        // OpenAI text and audio providers.
+        $this->assertStringStartsWith('msg_', $chunks[0]->messageId);
+
+        // Chunk contents come directly from the API payload.
+        $this->assertSame('PARTIAL_ONE', $chunks[0]->content);
+        $this->assertSame('PARTIAL_TWO', $chunks[1]->content);
+
+        // The final assistant message uses the completed image, not the last partial.
+        $this->assertInstanceOf(AssistantMessage::class, $message);
+        $image = $message->getContentBlocks()[0];
+        $this->assertInstanceOf(ImageContent::class, $image);
+        $this->assertSame('FINAL', $image->content);
+        $this->assertSame(SourceType::BASE64, $image->sourceType);
+        $this->assertSame('image/webp', $image->mediaType);
+
+        // Usage captured from the completed event only.
+        $this->assertSame(15, $message->getUsage()->inputTokens);
+        $this->assertSame(100, $message->getUsage()->outputTokens);
+    }
+
+    public function test_stream_supports_partial_images_zero_returning_only_completed(): void
+    {
+        $streamBody = 'data: {"type":"image_generation.completed","b64_json":"ONLY","usage":{"input_tokens":5,"output_tokens":42}}'."\n\n";
+        $streamBody .= "data: [DONE]\n\n";
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $streamBody),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        $generator = $provider->stream(new UserMessage('A dog'));
+
+        $chunks = [];
+        foreach ($generator as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        $message = $generator->getReturn();
+
+        $this->assertCount(0, $chunks);
+        $image = $message->getContentBlocks()[0];
+        $this->assertInstanceOf(ImageContent::class, $image);
+        $this->assertSame('ONLY', $image->content);
+        $this->assertSame(42, $message->getUsage()->outputTokens);
+    }
+
+    public function test_stream_sends_stream_flag_and_parameters_in_request_body(): void
+    {
+        $sentRequests = [];
+        $history = Middleware::history($sentRequests);
+
+        $streamBody = 'data: {"type":"image_generation.completed","b64_json":"ONLY"}'."\n\n";
+        $streamBody .= "data: [DONE]\n\n";
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $streamBody),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push($history);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            output_format: 'png',
+            parameters: ['partial_images' => 3, 'size' => '1024x1024'],
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        foreach ($provider->stream(new UserMessage('A fox')) as $chunk) {
+            // drain generator
+        }
+
+        $this->assertCount(1, $sentRequests);
+        $body = json_decode((string) $sentRequests[0]['request']->getBody(), true);
+        $this->assertTrue($body['stream']);
+        $this->assertSame(3, $body['partial_images']);
+        $this->assertSame('1024x1024', $body['size']);
+        $this->assertSame('A fox', $body['prompt']);
+    }
+
+    public function test_stream_throws_provider_exception_on_error_event(): void
+    {
+        // Real error payload shape as sent by the OpenAI Images streaming API.
+        $streamBody = 'data: {"type":"error","error":{"type":"image_generation_server_error","code":"image_generation_failed","message":"Image generation failed","param":null}}'."\n\n";
+        $streamBody .= "data: [DONE]\n\n";
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $streamBody),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('Image generation failed');
+
+        foreach ($provider->stream(new UserMessage('A fox')) as $chunk) {
+            // drain generator — should throw before yielding
+        }
+    }
+
+    public function test_stream_throws_when_stream_closes_before_completed_event(): void
+    {
+        // Stream drops after partials — no completed event. The old code would
+        // silently return the last partial as the "final" image.
+        $streamBody = 'data: {"type":"image_generation.partial_image","partial_image_index":0,"b64_json":"PARTIAL_ONE"}'."\n\n";
+        $streamBody .= "data: [DONE]\n\n";
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $streamBody),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('stream ended before a completed image');
+
+        $generator = $provider->stream(new UserMessage('A fox'));
+        foreach ($generator as $chunk) {
+            // drain
+        }
+        $generator->getReturn(); // triggers the post-loop assertion
+    }
+
+    public function test_stream_throws_when_completed_event_has_no_b64_json(): void
+    {
+        $streamBody = 'data: {"type":"image_generation.completed"}'."\n\n";
+        $streamBody .= "data: [DONE]\n\n";
+
+        $mockHandler = new MockHandler([
+            new Response(status: 200, body: $streamBody),
+        ]);
+        $stack = HandlerStack::create($mockHandler);
+
+        $provider = new OpenAIImage(
+            key: 'test-key',
+            model: 'gpt-image-1',
+            httpClient: new GuzzleHttpClient(handler: $stack),
+        );
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('completed image event without b64_json');
+
+        foreach ($provider->stream(new UserMessage('A fox')) as $chunk) {
+            // drain
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Description

### What does this PR do?

Fixes three bugs in `OpenAIImage::stream()`.

Main one: it passes `partial_image_index` into `ImageChunk` as the message id. That value is an int, so under `strict_types` it dies on the first SSE event.

Also, `image_generation.completed` wasn't handled, so an early stream close could return the last partial as the final image. And `{"type":"error", ...}` events were ignored instead of throwing.

Public API stays the same. The generator still yields `ImageChunk` for partial events and returns an `AssistantMessage` at the end, but the final image and usage now come from `image_generation.completed`.

### Why is this change needed?

Stream method is currently unusable — errors out on the first SSE event from the real API.

### How does this change should be used and documented?

No usage changes. Same call site as before.

## Related Issues

Fixes #541

## Testing

- [x] I have tested this change locally
- [x] I have added/updated unit tests where appropriate
- [x] All existing tests pass
- [x] I have tested this with different PHP versions (if applicable)

Added 7 tests in `tests/Providers/OpenAIImageTest.php` covering partial chunks, completed-only streaming, request payload shape, API error events, truncated streams, missing `b64_json`, and the existing non-streaming `chat()` path.

## Breaking Changes

- [x] No breaking changes

`ImageChunk` untouched. `messageId` is generated once per stream via `UniqueIdGenerator::generateId('msg_')`, matching `OpenAITextToSpeech` / `OpenAISpeechToText`.

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] My code follows the project's coding standards (PHPStan)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My commit messages are clear and descriptive
- [x] This PR addresses only ONE specific goal/issue

## Additional Notes

OpenAI reference: https://developers.openai.com/api/reference/resources/images/generation-streaming-events

If you'd rather keep this to the type fix, I can split the error/truncation changes into a follow-up PR. LMK.