### PR TITLE
fix: add null coalesce checks for optional SSE event fields in Handle…

### DIFF
--- a/src/Providers/OpenAI/HandleStream.php
+++ b/src/Providers/OpenAI/HandleStream.php
@@ -68,7 +68,7 @@ trait HandleStream
                 continue;
             }
 
-            $this->streamState->messageId($line['id']);
+            $this->streamState->messageId($line['id'] ?? null);
 
             // Capture usage information
             if (!empty($line['usage'])) {
@@ -152,7 +152,7 @@ trait HandleStream
     {
         $content = $choice['delta']['content'] ?? null;
         if ($content !== null) {
-            $this->streamState->updateContentBlock($choice['index'], new TextContent($content));
+            $this->streamState->updateContentBlock($choice['index'] ?? 0, new TextContent($content));
             yield new TextChunk($this->streamState->messageId(), $content);
         }
     }


### PR DESCRIPTION
## Summary

Fixed "Undefined array key" errors when processing SSE streaming responses from OpenAI-compatible APIs (e.g., Ollama, LM Studio, custom endpoints) that may not include all fields in every event.

## Changes

### HandleStream.php

1. **Line 71** - Added null coalesce for `id` field:
   ```php
   // Before
   $this->streamState->messageId($line['id']);
   
   // After
   $this->streamState->messageId($line['id'] ?? null);

2. Line 155 - Added null coalesce for index field:
   ```php
    // Before
    $this->streamState->updateContentBlock($choice['index'], new TextContent($content));
  
    // After
    $this->streamState->updateContentBlock($choice['index'] ?? 0, new TextContent($content));
    ```

**Root Cause**
Some OpenAI-compatible API providers don't include id and index fields in every SSE event. The library assumed these fields were always present, causing crashes when using non-standard providers.