### PR TITLE
fix(openai-responses): wrap ToolCallMessage content blocks in assistant message

### DIFF
--- a/src/Providers/OpenAI/Responses/MessageMapper.php
+++ b/src/Providers/OpenAI/Responses/MessageMapper.php
@@ -21,7 +21,6 @@ use stdClass;
 
 use function array_filter;
 use function array_map;
-use function array_merge;
 use function array_values;
 use function json_encode;
 
@@ -133,7 +132,13 @@ class MessageMapper implements MessageMapperInterface
     {
         // Add content blocks if present
         if ($contentBlocks = $message->getContentBlocks()) {
-            $this->mapping = array_merge($this->mapping, $this->mapBlocks($contentBlocks, false));
+            $blocks = $this->mapBlocks($contentBlocks, false);
+            if (! empty($blocks)) {
+                $this->mapping[] = [
+                    'role' => 'assistant',
+                    'content' => $blocks,
+                ];
+            }
         }
 
         // Add function call items


### PR DESCRIPTION
## Problem

When using the OpenAI Responses API with tool calls, if a `ToolCallMessage` contains content blocks (e.g. `output_text` from a previous assistant turn), they were being merged directly into the top-level input array as bare items:

```json
[
  { "type": "output_text", "text": "..." },   // ❌ top-level, invalid
  { "type": "function_call", "name": "...", ... }
]
```

The Responses API rejects this — `output_text` items must be nested inside a proper assistant message object.

## Fix

Wrap the mapped content blocks in `{role: 'assistant', content: [...]}` before appending to the mapping:

```json
[
  { "role": "assistant", "content": [{ "type": "output_text", "text": "..." }] },  // ✅
  { "type": "function_call", "name": "...", ... }
]
```

## Impact

Without this fix, any multi-turn conversation that includes a `ToolCallMessage` with content blocks causes a provider exception, breaking all tool-calling flows with the OpenAI Responses API after the first assistant turn that has both text and tool calls.

Fixes #556