### PR TITLE
Tavily web search tool - fix array syntax for time_range property options

### DIFF
--- a/src/Tools/Toolkits/Tavily/TavilySearchTool.php
+++ b/src/Tools/Toolkits/Tavily/TavilySearchTool.php
@@ -70,7 +70,7 @@ class TavilySearchTool extends Tool
                 PropertyType::STRING,
                 'How far back to search for relevant contents.',
                 false,
-                ['day, week, month, year']
+                ['day', 'week', 'month', 'year']
             ),
             new ToolProperty(
                 'days',


### PR DESCRIPTION
Tavily web search isn't working correctly when time range options are used.