### PR TITLE
Add multimodal content support and fix empty tool input for AWS Bedrock

### DIFF
--- a/src/Providers/AWS/MessageMapper.php
+++ b/src/Providers/AWS/MessageMapper.php
@@ -4,18 +4,31 @@ declare(strict_types=1);
 
 namespace NeuronAI\Providers\AWS;
 
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\Messages\ContentBlocks\AudioContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ContentBlockInterface;
+use NeuronAI\Chat\Messages\ContentBlocks\FileContent;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
 use NeuronAI\Chat\Messages\ContentBlocks\ReasoningContent;
 use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+use NeuronAI\Chat\Messages\ContentBlocks\VideoContent;
 use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Chat\Messages\ToolCallMessage;
 use NeuronAI\Chat\Messages\ToolResultMessage;
 use NeuronAI\Providers\MessageMapperInterface;
+use stdClass;
 
 use function array_map;
 use function array_merge;
 use function array_filter;
 use function array_values;
+use function base64_decode;
+use function end;
+use function explode;
+use function preg_replace;
+use function strtolower;
+use function trim;
+use function uniqid;
 
 class MessageMapper implements MessageMapperInterface
 {
@@ -66,7 +79,8 @@ class MessageMapper implements MessageMapperInterface
             $toolCallContents[] = [
                 'toolUse' => [
                     'name' => $tool->getName(),
-                    'input' => $tool->getInputs(),
+                    // AWS Converse requires a JSON object; empty PHP array would serialize to [].
+                    'input' => $tool->getInputs() !== [] ? $tool->getInputs() : new stdClass(),
                     'toolUseId' => $tool->getCallId(),
                 ],
             ];
@@ -104,6 +118,119 @@ class MessageMapper implements MessageMapperInterface
             return ['text' => $block->content];
         }
 
+        if ($block instanceof ImageContent) {
+            return $this->mapImageBlock($block);
+        }
+
+        if ($block instanceof FileContent) {
+            return $this->mapFileBlock($block);
+        }
+
+        if ($block instanceof AudioContent) {
+            return $this->mapAudioBlock($block);
+        }
+
+        if ($block instanceof VideoContent) {
+            return $this->mapVideoBlock($block);
+        }
+
         return null;
+    }
+
+    protected function mapImageBlock(ImageContent $block): ?array
+    {
+        $source = $this->mapMediaSource($block->sourceType, $block->content);
+        if ($source === null) {
+            return null;
+        }
+
+        return [
+            'image' => [
+                'format' => $this->extractFormat($block->mediaType),
+                'source' => $source,
+            ],
+        ];
+    }
+
+    protected function mapFileBlock(FileContent $block): ?array
+    {
+        $source = $this->mapMediaSource($block->sourceType, $block->content);
+        if ($source === null) {
+            return null;
+        }
+
+        $format = $this->extractFormat($block->mediaType);
+
+        return [
+            'document' => [
+                'format' => $format,
+                'name' => $this->buildDocumentName($block->filename, $format),
+                'source' => $source,
+            ],
+        ];
+    }
+
+    protected function buildDocumentName(?string $filename, ?string $format): string
+    {
+        $name = $filename ?? 'document-' . uniqid();
+        // AWS Converse rule: alphanumeric, whitespace, hyphens, parentheses, square brackets only; no consecutive whitespace.
+        $name = preg_replace('/[^a-zA-Z0-9\s\-()\[\]]/', '-', $name) ?? $name;
+        $name = preg_replace('/\s+/', ' ', $name) ?? $name;
+        $name = trim($name);
+
+        return $name === '' ? 'document-' . uniqid() . ($format !== null ? '-' . $format : '') : $name;
+    }
+
+    protected function mapAudioBlock(AudioContent $block): ?array
+    {
+        $source = $this->mapMediaSource($block->sourceType, $block->content);
+        if ($source === null) {
+            return null;
+        }
+
+        return [
+            'audio' => [
+                'format' => $this->extractFormat($block->mediaType),
+                'source' => $source,
+            ],
+        ];
+    }
+
+    protected function mapVideoBlock(VideoContent $block): ?array
+    {
+        $source = $this->mapMediaSource($block->sourceType, $block->content);
+        if ($source === null) {
+            return null;
+        }
+
+        return [
+            'video' => [
+                'format' => $this->extractFormat($block->mediaType),
+                'source' => $source,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{bytes: string}|array{s3Location: array{uri: string}}|null
+     */
+    protected function mapMediaSource(SourceType $sourceType, string $content): ?array
+    {
+        return match ($sourceType) {
+            SourceType::BASE64 => ['bytes' => base64_decode($content, true) ?: $content],
+            SourceType::ID => ['s3Location' => ['uri' => $content]],
+            SourceType::URL => null,
+        };
+    }
+
+    protected function extractFormat(?string $mediaType): ?string
+    {
+        if ($mediaType === null) {
+            return null;
+        }
+
+        $parts = explode('/', $mediaType);
+
+        return strtolower(end($parts));
     }
 }

--- a/tests/Providers/BedrockRuntimeTest.php
+++ b/tests/Providers/BedrockRuntimeTest.php
@@ -7,16 +7,24 @@ namespace NeuronAI\Tests\Providers;
 use Aws\BedrockRuntime\BedrockRuntimeClient;
 use Aws\Result;
 use GuzzleHttp\Promise\FulfilledPromise;
+use NeuronAI\Chat\Enums\SourceType;
 use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\ContentBlocks\AudioContent;
+use NeuronAI\Chat\Messages\ContentBlocks\FileContent;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
+use NeuronAI\Chat\Messages\ContentBlocks\TextContent;
+use NeuronAI\Chat\Messages\ContentBlocks\VideoContent;
 use NeuronAI\Chat\Messages\ToolCallMessage;
 use NeuronAI\Chat\Messages\UserMessage;
 use NeuronAI\Providers\AWS\BedrockRuntime;
+use NeuronAI\Providers\AWS\MessageMapper;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function base64_encode;
 use function json_encode;
 
 class BedrockRuntimeTest extends TestCase
@@ -210,5 +218,223 @@ class BedrockRuntimeTest extends TestCase
         $this->assertSame('object', $toolSpec['inputSchema']['json']['type']);
         $this->assertSame([], $toolSpec['inputSchema']['json']['required']);
         $this->assertSame(json_encode(new stdClass()), json_encode($toolSpec['inputSchema']['json']['properties']));
+    }
+
+    public function test_tool_call_with_empty_input_serializes_as_json_object(): void
+    {
+        $tool = Tool::make('noop', 'no params');
+        $tool->setCallId('call-empty');
+        $tool->setInputs([]);
+
+        $message = new ToolCallMessage(null, [$tool]);
+
+        $mapped = (new MessageMapper())->map([$message]);
+
+        $toolUse = $mapped[0]['content'][0]['toolUse'];
+        $this->assertSame('noop', $toolUse['name']);
+        $this->assertSame('call-empty', $toolUse['toolUseId']);
+        // AWS Converse rejects '[]' for input; must be a JSON object '{}'.
+        $this->assertSame('{}', json_encode($toolUse['input']));
+    }
+
+    public function test_tool_call_with_inputs_passes_through_unchanged(): void
+    {
+        $tool = Tool::make('search', 'search the web');
+        $tool->setCallId('call-1');
+        $tool->setInputs(['query' => 'php']);
+
+        $message = new ToolCallMessage(null, [$tool]);
+
+        $mapped = (new MessageMapper())->map([$message]);
+
+        $this->assertSame(
+            ['query' => 'php'],
+            $mapped[0]['content'][0]['toolUse']['input'],
+        );
+    }
+
+    public function test_chat_request_with_base64_image(): void
+    {
+        $rawBytes = "\xff\xd8\xff\xe0\x00\x10JFIFbinaryjpegdata";
+        $base64 = base64_encode($rawBytes);
+
+        $message = new UserMessage([
+            new TextContent('Describe this image'),
+            new ImageContent($base64, SourceType::BASE64, 'image/jpeg'),
+        ]);
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $content = $capturedPayload['messages'][0]['content'];
+        $this->assertCount(2, $content);
+        $this->assertSame(['text' => 'Describe this image'], $content[0]);
+        $this->assertSame([
+            'image' => [
+                'format' => 'jpeg',
+                'source' => ['bytes' => $rawBytes],
+            ],
+        ], $content[1]);
+    }
+
+    public function test_chat_request_with_s3_image(): void
+    {
+        $message = new UserMessage(new ImageContent(
+            's3://my-bucket/path/to/image.png',
+            SourceType::ID,
+            'image/png',
+        ));
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $this->assertSame([
+            'image' => [
+                'format' => 'png',
+                'source' => ['s3Location' => ['uri' => 's3://my-bucket/path/to/image.png']],
+            ],
+        ], $capturedPayload['messages'][0]['content'][0]);
+    }
+
+    public function test_chat_request_with_url_image_is_dropped(): void
+    {
+        $message = new UserMessage([
+            new TextContent('Hi'),
+            new ImageContent('https://example.com/image.jpg', SourceType::URL, 'image/jpeg'),
+        ]);
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $content = $capturedPayload['messages'][0]['content'];
+        $this->assertCount(1, $content);
+        $this->assertSame(['text' => 'Hi'], $content[0]);
+    }
+
+    public function test_chat_request_with_pdf_document(): void
+    {
+        $rawBytes = "%PDF-1.4\nfake pdf bytes";
+        $base64 = base64_encode($rawBytes);
+
+        $message = new UserMessage(new FileContent(
+            $base64,
+            SourceType::BASE64,
+            'application/pdf',
+            'report.pdf',
+        ));
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        // AWS Converse rule strips '.' from filenames -> 'report.pdf' becomes 'report-pdf'.
+        $this->assertSame([
+            'document' => [
+                'format' => 'pdf',
+                'name' => 'report-pdf',
+                'source' => ['bytes' => $rawBytes],
+            ],
+        ], $capturedPayload['messages'][0]['content'][0]);
+    }
+
+    public function test_chat_request_with_pdf_document_without_filename_generates_name(): void
+    {
+        $rawBytes = '%PDF-1.4 anon';
+        $message = new UserMessage(new FileContent(
+            base64_encode($rawBytes),
+            SourceType::BASE64,
+            'application/pdf',
+        ));
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $document = $capturedPayload['messages'][0]['content'][0]['document'];
+        $this->assertSame('pdf', $document['format']);
+        $this->assertSame(['bytes' => $rawBytes], $document['source']);
+        $this->assertNotEmpty($document['name'], 'AWS Converse requires document.name to be present');
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9\s\-()\[\]]+$/', $document['name']);
+    }
+
+    public function test_chat_request_with_audio(): void
+    {
+        $rawBytes = "fakeaudiopayload";
+        $base64 = base64_encode($rawBytes);
+
+        $message = new UserMessage(new AudioContent($base64, SourceType::BASE64, 'audio/mp3'));
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $this->assertSame([
+            'audio' => [
+                'format' => 'mp3',
+                'source' => ['bytes' => $rawBytes],
+            ],
+        ], $capturedPayload['messages'][0]['content'][0]);
+    }
+
+    public function test_chat_request_with_video(): void
+    {
+        $rawBytes = "fakevideopayload";
+        $base64 = base64_encode($rawBytes);
+
+        $message = new UserMessage(new VideoContent($base64, SourceType::BASE64, 'video/mp4'));
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $this->assertSame([
+            'video' => [
+                'format' => 'mp4',
+                'source' => ['bytes' => $rawBytes],
+            ],
+        ], $capturedPayload['messages'][0]['content'][0]);
+    }
+
+    public function test_chat_request_with_mixed_content(): void
+    {
+        $imageBytes = "\xff\xd8\xffimg";
+        $docBytes = "%PDF-1.4doc";
+
+        $message = new UserMessage([
+            new TextContent('Compare these'),
+            new ImageContent(base64_encode($imageBytes), SourceType::BASE64, 'image/jpeg'),
+            new FileContent(base64_encode($docBytes), SourceType::BASE64, 'application/pdf', 'a.pdf'),
+        ]);
+
+        $capturedPayload = $this->dispatchAndCapturePayload($message);
+
+        $content = $capturedPayload['messages'][0]['content'];
+        $this->assertCount(3, $content);
+        $this->assertSame(['text' => 'Compare these'], $content[0]);
+        $this->assertArrayHasKey('image', $content[1]);
+        $this->assertSame($imageBytes, $content[1]['image']['source']['bytes']);
+        $this->assertArrayHasKey('document', $content[2]);
+        $this->assertSame('a-pdf', $content[2]['document']['name']);
+        $this->assertSame($docBytes, $content[2]['document']['source']['bytes']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function dispatchAndCapturePayload(UserMessage $message): array
+    {
+        $bedrockClient = $this->getMockBuilder(BedrockRuntimeClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['converseAsync'])
+            ->getMock();
+
+        $result = new Result([
+            'usage' => ['inputTokens' => 1, 'outputTokens' => 1],
+            'output' => ['message' => ['content' => [['text' => 'ok']]]],
+            'stopReason' => 'end_turn',
+        ]);
+
+        $capturedPayload = null;
+        $bedrockClient->expects($this->once())
+            ->method('converseAsync')
+            ->with($this->callback(function (array $payload) use (&$capturedPayload): bool {
+                $capturedPayload = $payload;
+                return true;
+            }))
+            ->willReturn(new FulfilledPromise($result));
+
+        $provider = new BedrockRuntime($bedrockClient, 'model-media');
+        $provider->chat($message);
+
+        return $capturedPayload;
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes for the AWS Bedrock Converse provider:

1. **Multimodal content blocks are now mapped to Converse format.** `ImageContent`, `FileContent`, `AudioContent`, and `VideoContent` were previously dropped silently by `MessageMapper::mapContentBlock()` (returned `null`). They are now mapped to Converse's `image`, `document`, `audio`, and `video` content blocks respectively.

2. **Empty tool input now serializes as `{}` instead of `[]`.** AWS Converse rejects `[]` for `toolUse.input` and requires a JSON object. Previously, any tool call with no parameters failed at the API boundary. Empty `array` is now coerced to `stdClass` so PHP's JSON encoder emits `{}`.

## Details

### Source-type handling (per `SourceType`)

| `SourceType` | Mapping |
|---|---|
| `BASE64` | `source.bytes` (decoded; raw content kept on decode failure) |
| `ID`     | `source.s3Location.uri` |
| `URL`    | dropped (Converse does not accept remote URLs) |

### Document name

`FileContent` requires `document.name` on Converse. The mapper:
- Sanitizes filenames to Converse's allowed charset (`a-zA-Z0-9 \-()[]`).
- Collapses consecutive whitespace.
- Falls back to a generated name (`document-<uniqid>[-<format>]`) when `filename` is `null` or sanitization yields an empty string.

### Format extraction

`mediaType` (e.g. `image/jpeg`, `application/pdf`) is split on `/` and lowercased to produce `format` (`jpeg`, `pdf`, `mp3`, `mp4`, ...).

## Test plan

- [x] `test_tool_call_with_empty_input_serializes_as_json_object` — empty input → `{}`
- [x] `test_tool_call_with_inputs_passes_through_unchanged` — non-empty input untouched
- [x] `test_chat_request_with_base64_image` — base64 → `bytes`
- [x] `test_chat_request_with_s3_image` — `ID` → `s3Location.uri`
- [x] `test_chat_request_with_url_image_is_dropped` — URL source returns `null` and is filtered out
- [x] `test_chat_request_with_pdf_document` — filename `report.pdf` sanitized to `report-pdf`
- [x] `test_chat_request_with_pdf_document_without_filename_generates_name` — generated name matches Converse charset
- [x] `test_chat_request_with_audio` — base64 audio → `audio.bytes`
- [x] `test_chat_request_with_video` — base64 video → `video.bytes`
- [x] `test_chat_request_with_mixed_content` — text + image + document in one message
- [x] PHPStan level 5 — clean
- [x] PHP-CS-Fixer — clean
- [x] Rector — clean

## Compatibility

Additive only. No public interface (`MessageMapperInterface`) signature change. Behavior change for empty tool inputs only affects payloads that previously errored at AWS, so no existing caller can rely on the old wire format.
