### PR TITLE
fix(gemini): add toolConfig AUTO mode to prevent built-in tool invocation

### DIFF
--- a/src/Providers/Gemini/HandleChat.php
+++ b/src/Providers/Gemini/HandleChat.php
@@ -14,12 +14,10 @@ use NeuronAI\Chat\Messages\Usage;
 use NeuronAI\Exceptions\HttpException;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\HttpClient\HttpRequest;
-
 use NeuronAI\Tools\ToolInterface;
 
 use function array_filter;
 use function array_key_exists;
-use function array_values;
 use function json_encode;
 
 trait HandleChat
@@ -46,17 +44,15 @@ trait HandleChat
         if (!empty($this->tools)) {
             $body['tools'] = $this->toolPayloadMapper()->map($this->tools);
 
-            $functionTools = array_values(array_filter(
-                $this->tools,
-                fn ($tool): bool => $tool instanceof ToolInterface
-            ));
-
-            if ($functionTools !== []) {
-                $body['toolConfig'] = [
-                    'functionCallingConfig' => [
-                        'mode' => 'AUTO',
-                    ],
-                ];
+            foreach ($this->tools as $tool) {
+                if ($tool instanceof ToolInterface) {
+                    $body['toolConfig'] = [
+                        'functionCallingConfig' => [
+                            'mode' => 'AUTO',
+                        ],
+                    ];
+                    break;
+                }
             }
         }
 

--- a/src/Providers/Gemini/HandleChat.php
+++ b/src/Providers/Gemini/HandleChat.php
@@ -15,8 +15,11 @@ use NeuronAI\Exceptions\HttpException;
 use NeuronAI\Exceptions\ProviderException;
 use NeuronAI\HttpClient\HttpRequest;
 
+use NeuronAI\Tools\ToolInterface;
+
 use function array_filter;
 use function array_key_exists;
+use function array_values;
 use function json_encode;
 
 trait HandleChat
@@ -42,6 +45,19 @@ trait HandleChat
 
         if (!empty($this->tools)) {
             $body['tools'] = $this->toolPayloadMapper()->map($this->tools);
+
+            $functionTools = array_values(array_filter(
+                $this->tools,
+                fn ($tool): bool => $tool instanceof ToolInterface
+            ));
+
+            if ($functionTools !== []) {
+                $body['toolConfig'] = [
+                    'functionCallingConfig' => [
+                        'mode' => 'AUTO',
+                    ],
+                ];
+            }
         }
 
         $response = $this->httpClient->request(

--- a/tests/Providers/GeminiTest.php
+++ b/tests/Providers/GeminiTest.php
@@ -300,6 +300,11 @@ class GeminiTest extends TestCase
                     ],
                 ],
             ],
+            'toolConfig' => [
+                'functionCallingConfig' => [
+                    'mode' => 'AUTO',
+                ],
+            ],
         ];
 
         $this->assertSame($expectedRequest, json_decode((string) $request['request']->getBody()->getContents(), true));


### PR DESCRIPTION
## Problem

When Gemini thinking models (e.g. 2.5 Pro) are given function tools, they can spontaneously invoke built-in provider-side tools like `run` (code execution). Since these are never registered in NeuronAI's tool list, `findTool()` throws a `ProviderException`:

```
The model is asking for a non-existing tool: run. You could try writing more verbose tool descriptions and prompts to help the model in the task.
```

## Fix

Set `toolConfig.functionCallingConfig.mode = AUTO` in the Gemini chat request whenever function tools are present. This explicitly tells Gemini to use standard function-calling behaviour without activating built-in provider tools like code execution or Google Search.

`AUTO` is Gemini's documented default for function calling and does not restrict which of our declared functions the model may call — it simply prevents it from reaching for built-in tools that NeuronAI has no knowledge of.

## References

- [Gemini function calling modes](https://ai.google.dev/gemini-api/docs/function-calling#function-calling-modes)